### PR TITLE
Push Notifications (Ticket 53) + EAS Build Scaffolding (Ticket 54)

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,65 @@
+# EAS Build workflow — manual trigger only while credentials are still being set up.
+# Once `__PLACEHOLDER_*__` values in eas.json are replaced and EXPO_TOKEN is configured
+# as a repo secret, this can be extended with `push:` or `schedule:` triggers.
+#
+# Secrets required:
+#   - EXPO_TOKEN: access token from https://expo.dev/settings/access-tokens
+#   - EXPO_PUBLIC_API_URL (optional): if injecting env at build time instead of via eas.json
+#
+# See .claude/placeholder-tokens.md for the authoritative list of tokens this workflow
+# and the rest of the EAS setup reference.
+
+name: EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - ios
+          - android
+      profile:
+        description: "EAS build profile"
+        required: true
+        default: "preview"
+        type: choice
+        options:
+          - development
+          - preview
+          - production
+
+jobs:
+  build:
+    name: eas build (${{ github.event.inputs.platform }} / ${{ github.event.inputs.profile }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Set up EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build via EAS
+        run: |
+          eas build \
+            --platform ${{ github.event.inputs.platform }} \
+            --profile ${{ github.event.inputs.profile }} \
+            --non-interactive \
+            --no-wait

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ app-example
 /android
 .env
 .claude/
+
+# Native signing — never commit
+credentials.json
+*.keystore
+google-services.json
+GoogleService-Info.plist

--- a/app.json
+++ b/app.json
@@ -31,7 +31,12 @@
     "plugins": [
       [
         "expo-notifications",
-        {}
+        {
+          "icon": "./assets/images/icon.png",
+          "color": "#ffffff",
+          "androidMode": "default",
+          "androidCollapsedTitle": "csc289mobile"
+        }
       ],
       "expo-router",
       [

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,5 +1,10 @@
+import { useNotificationSetup } from "@/features/notifications/hooks/useNotificationSetup";
 import { Stack } from "expo-router";
+
 export default function AuthLayout() {
+  /** Register device for push notifications once the user is authenticated. */
+  useNotificationSetup();
+
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(tabs)" />
@@ -47,7 +52,6 @@ export default function AuthLayout() {
           headerBackTitle: "Back",
         }}
       />
-      
     </Stack>
   );
 }

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,10 +1,10 @@
-import { useNotificationSetup } from "@/features/notifications/hooks/useNotificationSetup";
 import { Stack } from "expo-router";
 
 export default function AuthLayout() {
-  /** Register device for push notifications once the user is authenticated. */
-  useNotificationSetup();
-
+  // Push notification registration moved to the root layout (via the
+  // <NotificationRegistrar /> component) so the token dance starts before
+  // auth completes; the mutation inside `useNotificationSetup` auth-gates
+  // itself, so calling here too would just double-register.
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(tabs)" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,8 @@
 import { useAuthStore } from '@/features/auth/store';
+import { useNotificationSetup } from '@/features/notifications/hooks/useNotificationSetup';
 import { queryClient } from '@/lib/queryClient';
 import { PortalHost } from '@rn-primitives/portal';
 import { QueryClientProvider } from '@tanstack/react-query';
-// import { registerForPushNotificationsAsync } from '@/lib/notifications';
-// import Notifications from 'expo-notifications';
 import { Slot, useRouter, useSegments } from 'expo-router';
 import { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
@@ -11,6 +10,17 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { toastConfig } from '@/components/ToastConfig';
 import '../global.css';
+
+/**
+ * Thin wrapper that calls `useNotificationSetup` inside the React Query
+ * provider so `useRegisterPushToken` (a `useMutation` call) has a client to
+ * attach to. Rendering `null` keeps the hook's effects but adds nothing to
+ * the tree.
+ */
+function NotificationRegistrar() {
+  useNotificationSetup();
+  return null;
+}
 
 /**
  * Root layout — the single component that wraps every screen in the app.
@@ -32,7 +42,6 @@ import '../global.css';
  * full-screen spinner is shown so users never see a flash of the wrong screen.
  */
 export default function RootLayout() {
-  // const [pushToken, setPushToken] = useState<string | null>(null);
   const initializeAuth = useAuthStore((s) => s.initialize);
   const isLoading = useAuthStore((s) => s.isLoading);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -74,6 +83,8 @@ export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <SafeAreaProvider>
+        {/* Fires push-token registration early; self-gates on auth. */}
+        <NotificationRegistrar />
         <Slot />
         <PortalHost />
         <Toast config={toastConfig} />

--- a/docs/native-build.md
+++ b/docs/native-build.md
@@ -1,0 +1,117 @@
+# Native build guide (iOS + Android via EAS)
+
+Canonical process for producing installable native builds of `csc289mobile` using Expo Application Services (EAS). Applies to ticket 54.
+
+## Status as of 2026-04-18
+
+- `app.json` production-ready — bundle IDs, EAS project ID, icons, splash, plugins, New Arch enabled.
+- `eas.json` scaffolded with `development`, `preview`, `production` profiles and a `submit.production` block.
+- **Credentials not yet configured.** D3adMan does not have an active Apple Developer membership or local Android Studio setup. Every credential reference in `eas.json` / `credentials.json` is a placeholder `__PLACEHOLDER_<NAME>__` — see `.claude/placeholder-tokens.md` for the index.
+- No actual builds have been run. This doc is a blueprint so D3adMan (or whoever takes over) can execute the build once credentials exist.
+
+## Prerequisites
+
+- Node.js 22.x (matches what CI will use).
+- `eas-cli` globally: `npm install -g eas-cli`.
+- `EXPO_TOKEN` environment variable for non-interactive / CI use (generate from [expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens)).
+- Logged into the right Expo account: `eas whoami` should return `csc289-sp2026` (the `owner` on `app.json`).
+
+## Build profiles (`eas.json`)
+
+| Profile       | iOS output                  | Android output         | Distribution | Purpose                                |
+|---------------|-----------------------------|-----------------------|--------------|----------------------------------------|
+| `development` | simulator build (+dev client) | `.apk`                | internal     | local dev on simulator / sideloaded APK |
+| `preview`     | ad-hoc `.ipa`                | `.apk`                | internal     | internal testers / demo devices         |
+| `production`  | App Store `.ipa`             | Play Store `.aab`     | store        | release to TestFlight / Play internal   |
+
+Each profile has an `env` block with a placeholder `EXPO_PUBLIC_API_URL`. Fill these in (either by editing `eas.json`, using EAS Secrets, or passing `--env-file=...`) before running a build.
+
+## Running a build
+
+```
+# Dev build — intended for simulator / internal APK
+eas build --platform ios      --profile development
+eas build --platform android  --profile development
+
+# Internal preview (OTA-distributable URL from EAS)
+eas build --platform all --profile preview
+
+# Production (signed for store upload)
+eas build --platform all --profile production
+```
+
+For CI / non-interactive use, add `--non-interactive --no-wait`.
+
+## Submitting to stores
+
+```
+# Only after production builds complete and credentials are set
+eas submit --platform ios     --profile production
+eas submit --platform android --profile production
+```
+
+Submit reads from `eas.json#submit.production`:
+
+- **iOS:** `appleId`, `ascAppId`, `appleTeamId` — all placeholders right now. Values come from:
+  - `appleId` — the email on your Apple Developer account.
+  - `ascAppId` — the numeric "App ID" from App Store Connect → your app → App Information.
+  - `appleTeamId` — 10-character alphanumeric, from [developer.apple.com → Membership](https://developer.apple.com/account).
+- **Android:** `serviceAccountKeyPath` — path to a Google Play Service Account JSON. Placeholder until D3adMan downloads one from Google Play Console → Settings → API access. `track: internal` + `releaseStatus: draft` means submissions go to Internal Testing as drafts — safe default for first submit.
+
+## Credentials / signing
+
+Details in `docs/signing-setup.md`. Short version:
+
+- iOS: either let EAS manage certs (recommended — `eas credentials`) or provide a `.p12` + `.mobileprovision` via `credentials.json`.
+- Android: either let EAS generate a keystore (recommended) or provide your own via `credentials.json`.
+
+The repo's `.gitignore` excludes `credentials.json`, `google-services.json`, `GoogleService-Info.plist`, and any `.keystore/.jks/.p12/.p8` files — these are **local-only** and never committed.
+
+## Environment variables
+
+The mobile app reads `process.env.EXPO_PUBLIC_API_URL` (and only that — confirm via `lib/env.ts`). Set it per environment:
+
+| Where           | How                                                                               |
+|-----------------|-----------------------------------------------------------------------------------|
+| Local dev       | `.env` at repo root (gitignored)                                                  |
+| EAS build       | `eas.json#build.<profile>.env`, or `eas secret:create` then referenced by name    |
+| GitHub Actions  | repo secret `EXPO_PUBLIC_API_URL` injected into the workflow                      |
+
+**Do not commit the real URL to `eas.json`.** Use `eas secret:create --scope project --name EXPO_PUBLIC_API_URL --value "..."` and reference as `"$EXPO_PUBLIC_API_URL"` instead of the literal placeholder.
+
+## Push notifications in builds
+
+The app uses `expo-notifications`. For pushes to actually fire on a production build:
+
+- **iOS:** enable Push Notifications capability on the provisioning profile. If you let EAS manage credentials, this is automatic once the capability is on the App ID.
+- **Android:** provide a `google-services.json` (from Firebase — `__PLACEHOLDER_GOOGLE_SERVICES_FILE_PATH__`). Reference it from `app.json → android.googleServicesFile` (currently absent — add once you have the file). This doc notes the gap; see ticket 53 proposed-changes for where the server-side sends pushes through the Expo Push API.
+
+## GitHub Actions (CI builds)
+
+`.github/workflows/eas-build.yml` has a scaffolded workflow:
+
+- Manual trigger (`workflow_dispatch`) only — won't fire on every push to avoid surprising builds while credentials are incomplete.
+- Requires repo secret `EXPO_TOKEN`.
+- Defaults to `--platform all --profile preview`.
+- Enable push-trigger or schedule triggers when you're ready for automated builds.
+
+## Troubleshooting (pre-filled from common cases)
+
+| Symptom                                                 | Likely cause                                               | Fix                                                                      |
+|---------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------------|
+| `eas build` prompts for credentials every time          | No `credentials.json`, and haven't run `eas credentials`   | Run `eas credentials` once per platform to let EAS manage them           |
+| iOS build fails with "No provisioning profile"          | Capability mismatch between App ID and profile              | `eas credentials` → sync. Or add capability on developer.apple.com       |
+| Android build works but app crashes on launch           | Missing native module or wrong minSDK                       | Check `expo-dev-client` version matches `expo` major; rebuild dev client |
+| Push notifications silent on Android                    | No `google-services.json` referenced in `app.json`          | Drop the file in repo root (gitignored), add `android.googleServicesFile`|
+| `EXPO_PUBLIC_API_URL` still showing placeholder at run  | `eas.json` still has literal `__PLACEHOLDER_*_API_URL__`    | Set EAS Secret + reference by name, or edit `eas.json` locally           |
+
+## When D3adMan gets Apple + Android set up
+
+Follow-up work, in order:
+
+1. Replace every `__PLACEHOLDER_*__` in `eas.json` with real values (or EAS Secret references).
+2. Drop real `credentials.json` / `google-services.json` / `GoogleService-Info.plist` in repo root — `.gitignore` already hides them.
+3. Run `eas build --platform ios --profile development` once to confirm signing resolves.
+4. Run a `preview` build for each platform; install on a physical device; verify: app launches, can log in, can browse products, place a test order.
+5. Verify push notifications fire end-to-end (needs ticket 53 server-side changes).
+6. Only then run `production` builds and `eas submit`.

--- a/docs/signing-setup.md
+++ b/docs/signing-setup.md
@@ -1,0 +1,129 @@
+# Native signing setup (iOS + Android)
+
+Walks through getting signing credentials in place for `eas build` and `eas submit`. Companion to `docs/native-build.md`.
+
+## Two approaches
+
+1. **EAS-managed credentials (recommended for most cases).** EAS generates and stores certs/keys on Expo's servers. You run `eas credentials` interactively once per platform; EAS handles everything.
+2. **Self-managed via `credentials.json`.** You drop the cert + provisioning profile (iOS) and keystore (Android) in the repo root as a `credentials.json` file that points to the actual artefacts. Needed if you have strict signing requirements or need to match an existing Apple cert that's shared with a non-Expo team.
+
+This project defaults to EAS-managed. `credentials.json` is gitignored so it can exist locally if someone later switches to self-managed without leaking secrets.
+
+## iOS
+
+### What you need
+
+| Item                            | Where to get it                                                            | Placeholder token                           |
+|---------------------------------|----------------------------------------------------------------------------|---------------------------------------------|
+| Apple Developer account         | [developer.apple.com](https://developer.apple.com/) — paid membership ($99/yr) | (no token — account required)              |
+| Apple Team ID (10 chars)        | developer.apple.com → Membership page                                      | `__PLACEHOLDER_APPLE_TEAM_ID__`             |
+| Apple ID email                  | The email on the Apple Developer account                                   | `__PLACEHOLDER_APPLE_ID_EMAIL__`            |
+| App Store Connect App ID        | App Store Connect → your app → App Information → "Apple ID" (numeric)      | `__PLACEHOLDER_ASC_APP_ID__`                |
+| App-specific password (for `eas submit`) | [appleid.apple.com](https://appleid.apple.com) → Sign-In & Security → App-Specific Passwords | not stored in repo — set as EAS Secret or env var |
+| Distribution certificate + provisioning profile | EAS generates these for you on `eas credentials`       | tokens only if self-managed                 |
+
+### Steps (EAS-managed, preferred)
+
+```
+# 1. Log in to Expo + Apple via EAS
+eas login                              # asks for Expo credentials
+eas credentials --platform ios         # asks for Apple ID + Team; generates cert + profile
+
+# 2. Verify
+eas build --platform ios --profile development
+```
+
+### Steps (self-managed)
+
+1. Generate a Distribution Certificate (`.p12`) via Keychain Access (Mac) or `openssl`.
+2. Download a Provisioning Profile (`.mobileprovision`) from developer.apple.com.
+3. Place both in the repo root (already gitignored via `*.p12`, `*.mobileprovision` patterns).
+4. Create `credentials.json` at repo root with the template below.
+
+### `credentials.json` template (iOS portion)
+
+This file is **gitignored** — never commit. Local-only. Each placeholder below is listed in `.claude/placeholder-tokens.md`.
+
+```json
+{
+  "ios": {
+    "provisioningProfilePath": "__PLACEHOLDER_IOS_PROVISIONING_PROFILE_PATH__",
+    "distributionCertificate": {
+      "path": "__PLACEHOLDER_IOS_DISTRIBUTION_CERT_PATH__",
+      "password": "__PLACEHOLDER_IOS_DISTRIBUTION_CERT_PASSWORD__"
+    }
+  }
+}
+```
+
+## Android
+
+### What you need
+
+| Item                              | Where to get it                                                       | Placeholder token                              |
+|-----------------------------------|-----------------------------------------------------------------------|------------------------------------------------|
+| Android keystore (`.jks` / `.keystore`) | Generate via `keytool -genkey ...` or let EAS generate on `eas credentials` | `__PLACEHOLDER_ANDROID_KEYSTORE_PATH__`       |
+| Keystore password                 | Set during `keytool` generation                                       | `__PLACEHOLDER_ANDROID_KEYSTORE_PASSWORD__`    |
+| Key alias                         | Set during `keytool` generation                                       | `__PLACEHOLDER_ANDROID_KEY_ALIAS__`            |
+| Key password                      | Set during `keytool` generation (often same as keystore password)     | `__PLACEHOLDER_ANDROID_KEY_PASSWORD__`         |
+| Google Play Service Account JSON  | Google Play Console → Settings → API access → create service account  | `__PLACEHOLDER_GOOGLE_SERVICE_ACCOUNT_PATH__`  |
+| Firebase `google-services.json`   | Firebase Console → Project settings → Android app → download JSON     | `__PLACEHOLDER_GOOGLE_SERVICES_FILE_PATH__`    |
+
+### Steps (EAS-managed, preferred)
+
+```
+eas credentials --platform android     # prompts; generates keystore; stores on Expo
+eas build --platform android --profile development
+```
+
+### Steps (self-managed)
+
+1. Generate a keystore:
+   ```
+   keytool -genkeypair -v -keystore csc289mobile.keystore -alias csc289mobile -keyalg RSA -keysize 2048 -validity 10000
+   ```
+2. Place in repo root (gitignored via `*.jks` / new `*.keystore` line in `.gitignore`).
+3. Add Android section to `credentials.json`:
+
+```json
+{
+  "android": {
+    "keystore": {
+      "keystorePath": "__PLACEHOLDER_ANDROID_KEYSTORE_PATH__",
+      "keystorePassword": "__PLACEHOLDER_ANDROID_KEYSTORE_PASSWORD__",
+      "keyAlias": "__PLACEHOLDER_ANDROID_KEY_ALIAS__",
+      "keyPassword": "__PLACEHOLDER_ANDROID_KEY_PASSWORD__"
+    }
+  }
+}
+```
+
+### Google Play submission
+
+1. Create a service account in Google Cloud Console.
+2. Grant it the "Service Account User" role in Google Play Console → Settings → API access.
+3. Download the JSON key. Place at `./__PLACEHOLDER_GOOGLE_SERVICE_ACCOUNT_PATH__.json` or update `eas.json#submit.production.android.serviceAccountKeyPath` to the real path.
+
+### Firebase / push notifications
+
+For Android push to work, you also need Firebase Cloud Messaging set up:
+
+1. [Firebase Console](https://console.firebase.google.com) → Add project → Add Android app with package `com.csc289sp2026.elevateretail`.
+2. Download `google-services.json`.
+3. Place at repo root (gitignored).
+4. Add to `app.json`:
+
+```json
+"android": {
+  "...": "...",
+  "googleServicesFile": "./google-services.json"
+}
+```
+
+(Currently missing — flagged in ticket 54 follow-up.)
+
+## Rotation / security notes
+
+- Every placeholder in this doc and in `eas.json` is logged in `.claude/placeholder-tokens.md`. Do a full-repo grep for `__PLACEHOLDER_` when rotating to make sure no reference is missed.
+- Once real credentials exist, strongly prefer EAS Secrets (`eas secret:create --scope project ...`) over putting values in `eas.json`. That way `eas.json` stays safe to commit.
+- If you commit a secret by accident, rotate it immediately — don't just revert the commit. Git history remembers.

--- a/eas.json
+++ b/eas.json
@@ -10,15 +10,44 @@
       "android": {
         "buildType": "apk"
       },
+      "ios": {
+        "simulator": true
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "__PLACEHOLDER_DEV_API_URL__"
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "__PLACEHOLDER_PREVIEW_API_URL__"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "__PLACEHOLDER_PROD_API_URL__"
+      }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "appleId": "__PLACEHOLDER_APPLE_ID_EMAIL__",
+        "ascAppId": "__PLACEHOLDER_ASC_APP_ID__",
+        "appleTeamId": "__PLACEHOLDER_APPLE_TEAM_ID__"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./__PLACEHOLDER_GOOGLE_SERVICE_ACCOUNT_PATH__.json",
+        "track": "internal",
+        "releaseStatus": "draft"
+      }
+    }
   }
 }

--- a/features/notifications/hooks/shared.ts
+++ b/features/notifications/hooks/shared.ts
@@ -1,0 +1,4 @@
+export const notificationQueryKeys = {
+  all: ["notifications"],
+  token: () => [...notificationsQueryKeys.all, "token"],
+};

--- a/features/notifications/hooks/shared.ts
+++ b/features/notifications/hooks/shared.ts
@@ -1,4 +1,7 @@
+// Query-key factory for anything the notifications feature caches in React Query.
+// Self-referential — `.token()` must use `notificationQueryKeys.all`, not the
+// typo'd plural that was here previously (would ReferenceError on first call).
 export const notificationQueryKeys = {
-  all: ["notifications"],
-  token: () => [...notificationsQueryKeys.all, "token"],
+  all: ["notifications"] as const,
+  token: () => [...notificationQueryKeys.all, "token"] as const,
 };

--- a/features/notifications/hooks/useNotificationSetup.tsx
+++ b/features/notifications/hooks/useNotificationSetup.tsx
@@ -1,22 +1,24 @@
+import { useAuthStore } from "@/features/auth/store";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useEffect } from "react";
 import { useRegisterPushToken } from "./useRegisterPushToken";
 
 /**
- * Handles push notification registration for authenticated users.
- *
- * Call this hook once inside the (auth) layout. It registers the device
- * for push notifications, retrieves the Expo push token from Apple/Google,
- * and sends it to the backend so the server can deliver notifications
- * for order events, shipping updates, and promotions.
+ * Mount once at the root — inside the `QueryClientProvider` ancestor — so we
+ * start the permission / token dance as early as possible. The mutation that
+ * sends the token to the backend is gated on `isAuthenticated` so we don't
+ * hit the protected endpoint while the user is logged out.
  */
 export const useNotificationSetup = () => {
   const { expoPushToken } = usePushNotifications();
   const { mutate: registerToken } = useRegisterPushToken();
+  // Auth-gate: the `POST /notifications/register-token` endpoint needs a
+  // signed-in user; firing before login would 401 and burn a retry budget.
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   useEffect(() => {
-    if (expoPushToken?.data) {
+    if (expoPushToken?.data && isAuthenticated) {
       registerToken({ token: expoPushToken.data });
     }
-  }, [expoPushToken]);
+  }, [expoPushToken, isAuthenticated]);
 };

--- a/features/notifications/hooks/useNotificationSetup.tsx
+++ b/features/notifications/hooks/useNotificationSetup.tsx
@@ -1,0 +1,22 @@
+import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { useEffect } from "react";
+import { useRegisterPushToken } from "./useRegisterPushToken";
+
+/**
+ * Handles push notification registration for authenticated users.
+ *
+ * Call this hook once inside the (auth) layout. It registers the device
+ * for push notifications, retrieves the Expo push token from Apple/Google,
+ * and sends it to the backend so the server can deliver notifications
+ * for order events, shipping updates, and promotions.
+ */
+export const useNotificationSetup = () => {
+  const { expoPushToken } = usePushNotifications();
+  const { mutate: registerToken } = useRegisterPushToken();
+
+  useEffect(() => {
+    if (expoPushToken?.data) {
+      registerToken({ token: expoPushToken.data });
+    }
+  }, [expoPushToken]);
+};

--- a/features/notifications/hooks/useRegisterPushToken.tsx
+++ b/features/notifications/hooks/useRegisterPushToken.tsx
@@ -1,0 +1,19 @@
+import { apiClient } from "@/lib/apiClient";
+import { unwrapResponse } from "@/lib/unwrapResponse";
+import { useMutation } from "@tanstack/react-query";
+import { RegisterPushTokenRequest } from "../types";
+
+/**
+ * Sends the device's Expo push token to the server so the backend
+ * can send push notifications to this device for order events,
+ * shipping updates, and promotional alerts.
+ *
+ * Called once after login when the app registers for notifications.
+ */
+export const useRegisterPushToken = () =>
+  useMutation({
+    mutationFn: (dto: RegisterPushTokenRequest) =>
+      apiClient
+        .POST("/api/notifications/register-token", { body: dto })
+        .then(unwrapResponse),
+  });

--- a/features/notifications/types.ts
+++ b/features/notifications/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Re-exported notification types.
+ * Will be populated once the backend endpoint and generated types exist.
+ */
+
+export interface RegisterPushTokenRequest {
+  /** The Expo push token returned by the device on registration.  */
+  token: string;
+}
+
+export interface RegisterPushTokenResponse {
+  /** Confirmation message from the server */
+  message: string;
+}

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -10,16 +10,20 @@ export interface PushNotificationState {
   expoPushToken?: Notifications.ExpoPushToken;
 }
 
-export const usePushNotifications = (): PushNotificationState => {
-  Notifications.setNotificationHandler({
-    handleNotification: async () => ({
-      shouldPlaySound: true,
-      shouldSetBadge: false,
-      shouldShowList: true,
-      shouldShowBanner: true,
-    }),
-  });
+// Module-scope: `setNotificationHandler` is a global config call, not per-hook state.
+// Invoking it inside the hook body re-registered the handler on every render; doing
+// it once at module load is what `expo-notifications` expects and matches Ian's
+// `upstream/ianfrye/playground` direction.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+    shouldShowList: true,
+    shouldShowBanner: true,
+  }),
+});
 
+export const usePushNotifications = (): PushNotificationState => {
   const [notification, setNotification] = useState<Notifications.Notification | undefined>(
     undefined,
   );

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,16 +20,18 @@ model Customer {
   Customer_ID      Int                @id @default(autoincrement())
   First_Name       String             @db.VarChar(50)
   Last_Name        String             @db.VarChar(50)
-  Email            String             @unique @db.VarChar(254)
+  Email            String             @unique(map: "Email") @db.VarChar(254)
   Phone            String?            @db.VarChar(20)
   Membership_Level String             @db.VarChar(50)
-  Created_At       DateTime           @default(now())
-  Updated_At       DateTime?
-  Deleted_At       DateTime?
-  member           Member             @relation(fields: [Membership_Level], references: [Membership_Level])
+  Created_At       DateTime           @default(now()) @db.DateTime(6)
+  Updated_At       DateTime?          @db.DateTime(6)
+  Deleted_At       DateTime?          @db.DateTime(6)
+  member           Member             @relation(fields: [Membership_Level], references: [Membership_Level], onDelete: NoAction, onUpdate: NoAction, map: "FK_Customer_Member")
   addresses        Customer_Address[]
-  carts            Shopping_Cart[]
   orders           Order[]
+  carts            Shopping_Cart[]
+
+  @@index([Membership_Level], map: "FK_Customer_Member")
 }
 
 model Customer_Address {
@@ -41,12 +43,14 @@ model Customer_Address {
   Zip_Code        String     @db.VarChar(10)
   Country         String     @db.VarChar(50)
   Customer_ID     Int
-  Created_At      DateTime   @default(now())
-  Updated_At      DateTime?
-  Deleted_At      DateTime?
-  customer        Customer   @relation(fields: [Customer_ID], references: [Customer_ID])
-  ShippingAddress Shipping[] @relation("ShippingAddress")
+  Created_At      DateTime   @default(now()) @db.DateTime(6)
+  Updated_At      DateTime?  @db.DateTime(6)
+  Deleted_At      DateTime?  @db.DateTime(6)
+  customer        Customer   @relation(fields: [Customer_ID], references: [Customer_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Address_Customer")
   BillingAddress  Shipping[] @relation("BillingAddress")
+  ShippingAddress Shipping[] @relation("ShippingAddress")
+
+  @@index([Customer_ID], map: "FK_Address_Customer")
 }
 
 model Product_Category {
@@ -57,18 +61,21 @@ model Product_Category {
 }
 
 model Product {
-  Product_ID          Int              @id @default(autoincrement())
-  Product_Name        String           @db.VarChar(100)
-  Product_Description String?          @db.VarChar(1000)
+  Product_ID          Int                   @id @default(autoincrement())
+  Product_Name        String                @db.VarChar(100)
+  Product_Description String?               @db.VarChar(1000)
   Category_ID         Int
   Supplier_ID         Int
-  Image_URL           String?          @db.VarChar(255)
-  Deleted_At          DateTime?
-  category            Product_Category @relation(fields: [Category_ID], references: [Category_ID])
-  supplier            Supplier         @relation(fields: [Supplier_ID], references: [Supplier_ID])
-  inventory           Inventory[]
+  Image_URL           String?               @db.VarChar(255)
+  Deleted_At          DateTime?             @db.DateTime(6)
   discounts           Discount[]
+  inventory           Inventory[]
+  category            Product_Category      @relation(fields: [Category_ID], references: [Category_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Product_Category")
+  supplier            Supplier              @relation(fields: [Supplier_ID], references: [Supplier_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Product_Supplier")
+  Purchase_Order_Item Purchase_Order_Item[]
 
+  @@index([Category_ID], map: "FK_Product_Category")
+  @@index([Supplier_ID], map: "FK_Product_Supplier")
   @@map("Product")
 }
 
@@ -77,43 +84,54 @@ model Inventory {
   Product_ID   Int
   Quantity     Int
   Unit_Price   Decimal              @db.Decimal(8, 2)
-  product      Product              @relation(fields: [Product_ID], references: [Product_ID])
-  cartItems    Shopping_Cart_Item[]
+  Deleted_At   DateTime?            @db.DateTime(6)
+  product      Product              @relation(fields: [Product_ID], references: [Product_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Inventory_Product")
   orderItems   Order_Item[]
+  cartItems    Shopping_Cart_Item[]
+
+  @@index([Product_ID], map: "FK_Inventory_Product")
 }
 
 model Shopping_Cart {
   Cart_ID     Int                  @id @default(autoincrement())
   Customer_ID Int
   Session_ID  String?              @db.VarChar(50)
-  Created_At  DateTime             @default(now())
-  Updated_At  DateTime?
-  customer    Customer             @relation(fields: [Customer_ID], references: [Customer_ID])
+  Created_At  DateTime             @default(now()) @db.DateTime(6)
+  Updated_At  DateTime?            @db.DateTime(6)
+  customer    Customer             @relation(fields: [Customer_ID], references: [Customer_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Cart_Customer")
   items       Shopping_Cart_Item[]
+
+  @@index([Customer_ID], map: "FK_Cart_Customer")
 }
 
 model Shopping_Cart_Item {
   Cart_ID      Int
   Inventory_ID Int
   Quantity     Int
-  Created_At   DateTime      @default(now())
-  Updated_At   DateTime?
-  cart         Shopping_Cart @relation(fields: [Cart_ID], references: [Cart_ID])
-  inventory    Inventory     @relation(fields: [Inventory_ID], references: [Inventory_ID])
+  Created_At   DateTime      @default(now()) @db.DateTime(6)
+  Updated_At   DateTime?     @db.DateTime(6)
+  cart         Shopping_Cart @relation(fields: [Cart_ID], references: [Cart_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_CartItem_Cart")
+  inventory    Inventory     @relation(fields: [Inventory_ID], references: [Inventory_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_CartItem_Inventory")
 
   @@id([Cart_ID, Inventory_ID])
+  @@index([Inventory_ID], map: "FK_CartItem_Inventory")
 }
 
 model Order {
-  Order_ID    Int          @id @default(autoincrement())
-  Customer_ID Int
-  Order_Date  DateTime     @default(now())
-  customer    Customer     @relation(fields: [Customer_ID], references: [Customer_ID])
-  items       Order_Item[]
-  payment     Payment?
-  shipping    Shipping?
-  discounts   Discount[]
+  Order_ID           Int             @id @default(autoincrement())
+  Customer_ID        Int
+  Order_Date         DateTime        @default(now()) @db.DateTime(6)
+  Order_Status       String          @default("Pending") @db.VarChar(50)
+  Fulfillment_Status String          @default("Pending") @db.VarChar(50)
+  Fulfilled_At       DateTime?       @db.DateTime(0)
+  discounts          Discount[]
+  customer           Customer        @relation(fields: [Customer_ID], references: [Customer_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Order_Customer")
+  Order_History      Order_History[]
+  items              Order_Item[]
+  payment            Payment[]
+  shipping           Shipping[]
 
+  @@index([Customer_ID], map: "FK_Order_Customer")
   @@map("Order")
 }
 
@@ -123,49 +141,62 @@ model Order_Item {
   Quantity     Int
   Amount       Decimal   @db.Decimal(8, 2)
   Tax          Decimal   @db.Decimal(8, 2)
-  Created_At   DateTime  @default(now())
-  Updated_At   DateTime?
-  order        Order     @relation(fields: [Order_ID], references: [Order_ID])
-  inventory    Inventory @relation(fields: [Inventory_ID], references: [Inventory_ID])
+  Created_At   DateTime  @default(now()) @db.DateTime(6)
+  Updated_At   DateTime? @db.DateTime(6)
+  inventory    Inventory @relation(fields: [Inventory_ID], references: [Inventory_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_OrderItem_Inventory")
+  order        Order     @relation(fields: [Order_ID], references: [Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_OrderItem_Order")
 
   @@id([Order_ID, Inventory_ID])
+  @@index([Inventory_ID], map: "FK_OrderItem_Inventory")
 }
 
 model Payment {
-  Payment_ID     Int       @id @default(autoincrement())
-  Order_ID       Int       @unique
-  Method         String    @db.VarChar(50)
-  Payment_Status String    @db.VarChar(50)
-  Created_At     DateTime  @default(now())
-  Updated_At     DateTime?
-  order          Order     @relation(fields: [Order_ID], references: [Order_ID])
+  Payment_ID           Int       @id @default(autoincrement())
+  Order_ID             Int
+  Method               String    @db.VarChar(50)
+  Payment_Status       String?   @db.VarChar(50)
+  Created_At           DateTime  @default(now()) @db.DateTime(6)
+  Updated_At           DateTime? @db.DateTime(6)
+  Payment_Confirmed_At DateTime? @db.DateTime(0)
+  order                Order     @relation(fields: [Order_ID], references: [Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Payment_Order")
+
+  @@index([Order_ID], map: "FK_Payment_Order")
 }
 
 model Supplier {
-  Supplier_ID   Int       @id @default(autoincrement())
-  Supplier_Name String    @db.VarChar(100)
-  Contact_Name  String    @db.VarChar(100)
-  Contact_Email String    @db.VarChar(254)
-  Contact_Phone String    @db.VarChar(20)
-  products      Product[]
+  Supplier_ID    Int              @id @default(autoincrement())
+  Supplier_Name  String           @db.VarChar(100)
+  Contact_Name   String           @db.VarChar(100)
+  Contact_Email  String           @db.VarChar(254)
+  Contact_Phone  String           @db.VarChar(20)
+  products       Product[]
+  Purchase_Order Purchase_Order[]
 }
 
 model Shipping {
-  Shipping_ID         Int              @id @default(autoincrement())
-  Order_ID            Int              @unique
-  Cost                Decimal          @db.Decimal(8, 2)
-  Shipped_On          DateTime?
-  Expected_By         DateTime?
-  Ship_Status         String           @db.VarChar(15)
-  Carrier             String           @db.VarChar(100)
-  Tracking_Number     String           @db.VarChar(50)
-  Created_At          DateTime         @default(now())
-  Updated_At          DateTime?
+  Shipping_ID         Int                @id @default(autoincrement())
+  Order_ID            Int
+  Cost                Decimal            @db.Decimal(8, 2)
+  Shipped_On          DateTime?          @db.DateTime(6)
+  Expected_By         DateTime?          @db.DateTime(6)
+  Ship_Status         String             @db.VarChar(15)
+  Carrier             String             @db.VarChar(100)
+  Tracking_Number     String             @db.VarChar(50)
+  Created_At          DateTime           @default(now()) @db.DateTime(6)
+  Updated_At          DateTime?          @db.DateTime(6)
   Shipping_Address_ID Int
   Billing_Address_ID  Int
-  order               Order            @relation(fields: [Order_ID], references: [Order_ID])
-  shippingAddress     Customer_Address @relation("ShippingAddress", fields: [Shipping_Address_ID], references: [Address_ID], onDelete: NoAction, onUpdate: NoAction)
-  billingAddress      Customer_Address @relation("BillingAddress", fields: [Billing_Address_ID], references: [Address_ID], onDelete: NoAction, onUpdate: NoAction)
+  Status_Updated_At   DateTime?          @db.DateTime(0)
+  Shipment_Notes      String?            @db.VarChar(255)
+  Return_Reason       String?            @db.VarChar(255)
+  billingAddress      Customer_Address   @relation("BillingAddress", fields: [Billing_Address_ID], references: [Address_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Billing_Address")
+  shippingAddress     Customer_Address   @relation("ShippingAddress", fields: [Shipping_Address_ID], references: [Address_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Shipping_Address")
+  order               Order              @relation(fields: [Order_ID], references: [Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Shipping_Order")
+  Shipping_History    Shipping_History[]
+
+  @@index([Billing_Address_ID], map: "FK_Billing_Address")
+  @@index([Shipping_Address_ID], map: "FK_Shipping_Address")
+  @@index([Order_ID], map: "FK_Shipping_Order")
 }
 
 model Discount {
@@ -176,8 +207,63 @@ model Discount {
   End_Date      DateTime @db.Date
   Product_ID    Int?
   Order_ID      Int?
-  product       Product? @relation(fields: [Product_ID], references: [Product_ID])
-  order         Order?   @relation(fields: [Order_ID], references: [Order_ID])
+  order         Order?   @relation(fields: [Order_ID], references: [Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Discount_Order")
+  product       Product? @relation(fields: [Product_ID], references: [Product_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_Discount_Product")
 
+  @@index([Order_ID], map: "FK_Discount_Order")
+  @@index([Product_ID], map: "FK_Discount_Product")
   @@map("Discount")
+}
+
+model Order_History {
+  Order_History_ID       Int      @id @default(autoincrement())
+  Order_ID               Int
+  Old_Order_Status       String?  @db.VarChar(50)
+  New_Order_Status       String   @db.VarChar(50)
+  Old_Fulfillment_Status String?  @db.VarChar(50)
+  New_Fulfillment_Status String?  @db.VarChar(50)
+  Changed_At             DateTime @default(now()) @db.DateTime(0)
+  Notes                  String?  @db.VarChar(255)
+  Order                  Order    @relation(fields: [Order_ID], references: [Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_OrderHistory_Order")
+
+  @@index([Order_ID], map: "FK_OrderHistory_Order")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+model Purchase_Order {
+  Purchase_Order_ID     Int                   @id @default(autoincrement())
+  Supplier_ID           Int
+  Order_Date            DateTime              @default(now()) @db.DateTime(6)
+  Purchase_Order_Status String                @db.VarChar(15)
+  Supplier              Supplier              @relation(fields: [Supplier_ID], references: [Supplier_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_PO_Supplier")
+  Purchase_Order_Item   Purchase_Order_Item[]
+
+  @@index([Supplier_ID], map: "FK_PO_Supplier")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+model Purchase_Order_Item {
+  Purchase_Order_Item_ID Int            @id @default(autoincrement())
+  Purchase_Order_ID      Int
+  Product_ID             Int
+  Quantity               Int
+  Created_At             DateTime       @default(now()) @db.DateTime(6)
+  Updated_At             DateTime?      @db.DateTime(6)
+  Purchase_Order         Purchase_Order @relation(fields: [Purchase_Order_ID], references: [Purchase_Order_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_POI_PO")
+  Product                Product        @relation(fields: [Product_ID], references: [Product_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_POI_Product")
+
+  @@index([Purchase_Order_ID], map: "FK_POI_PO")
+  @@index([Product_ID], map: "FK_POI_Product")
+}
+
+model Shipping_History {
+  Shipping_History_ID Int      @id @default(autoincrement())
+  Shipping_ID         Int
+  Old_Status          String?  @db.VarChar(15)
+  New_Status          String   @db.VarChar(15)
+  Changed_At          DateTime @default(now()) @db.DateTime(0)
+  Notes               String?  @db.VarChar(255)
+  Shipping            Shipping @relation(fields: [Shipping_ID], references: [Shipping_ID], onDelete: NoAction, onUpdate: NoAction, map: "FK_ShippingHistory_Shipping")
+
+  @@index([Shipping_ID], map: "FK_ShippingHistory_Shipping")
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,6 +4,7 @@ import { AddressesModule } from './features/addresses/addresses.module';
 import { AuthModule } from './features/auth/Auth.module';
 import { CartModule } from './features/cart/Cart.module';
 import { CustomerModule } from './features/customers/Customer.module';
+import { NotificationsModule } from './features/notifications/Notifications.module';
 import { OrdersModule } from './features/orders/Orders.module';
 import { ProductsModule } from './features/products/Products.module';
 import { HealthController } from './health.controller';
@@ -40,6 +41,7 @@ import { GlobalServicesModule } from './services/GlobalServices.module';
     OrdersModule,
     ProductsModule,
     AddressesModule,
+    NotificationsModule,
     // WebhooksModule,
   ],
   controllers: [HealthController],

--- a/server/src/features/notifications/Notifications.controller.ts
+++ b/server/src/features/notifications/Notifications.controller.ts
@@ -1,0 +1,24 @@
+import { User } from '@/decorators/User.decorator';
+import { Body, Controller, Post } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthUserDto } from '../auth/types/AuthUserDto.type';
+import { RegisterPushTokenCommand } from './commands/RegisterPushToken/RegisterPushTokenCommand';
+
+@ApiTags('Notifications')
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @Post('register-token')
+  @ApiOperation({ summary: 'Register device push token' })
+  @ApiOkResponse({ description: 'Token registered successfully' })
+  async registerToken(
+    @Body() body: { token: string },
+    @User() user: AuthUserDto,
+  ) {
+    return this.commandBus.execute(
+      new RegisterPushTokenCommand(user.id, body.token),
+    );
+  }
+}

--- a/server/src/features/notifications/Notifications.controller.ts
+++ b/server/src/features/notifications/Notifications.controller.ts
@@ -4,6 +4,7 @@ import { CommandBus } from '@nestjs/cqrs';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthUserDto } from '../auth/types/AuthUserDto.type';
 import { RegisterPushTokenCommand } from './commands/RegisterPushToken/RegisterPushTokenCommand';
+import { RegisterPushTokenRequestDto } from './dtos/RegisterPushTokenRequest.dto';
 
 @ApiTags('Notifications')
 @Controller('notifications')
@@ -14,7 +15,9 @@ export class NotificationsController {
   @ApiOperation({ summary: 'Register device push token' })
   @ApiOkResponse({ description: 'Token registered successfully' })
   async registerToken(
-    @Body() body: { token: string },
+    // Replaced inline `{ token: string }` with the validated DTO — Matches the
+    // codebase convention and adds format validation on the Expo push token.
+    @Body() body: RegisterPushTokenRequestDto,
     @User() user: AuthUserDto,
   ) {
     return this.commandBus.execute(

--- a/server/src/features/notifications/Notifications.module.ts
+++ b/server/src/features/notifications/Notifications.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { NotificationsController } from './Notifications.controller';
+import { RegisterPushTokenCommandHandler } from './commands/RegisterPushToken/RegisterPushTokenCommandHandler';
+
+@Module({
+  imports: [CqrsModule],
+  controllers: [NotificationsController],
+  providers: [RegisterPushTokenCommandHandler],
+})
+export class NotificationsModule {}

--- a/server/src/features/notifications/Notifications.module.ts
+++ b/server/src/features/notifications/Notifications.module.ts
@@ -2,10 +2,15 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { NotificationsController } from './Notifications.controller';
 import { RegisterPushTokenCommandHandler } from './commands/RegisterPushToken/RegisterPushTokenCommandHandler';
+import { ExpoPushService } from './services/ExpoPushService';
 
 @Module({
   imports: [CqrsModule],
   controllers: [NotificationsController],
-  providers: [RegisterPushTokenCommandHandler],
+  // ExpoPushService is exported so other feature modules (e.g. OrdersModule)
+  // can inject it to fire notifications on domain events — direct-send path,
+  // bypasses Ian's in-progress webhook module by design.
+  providers: [RegisterPushTokenCommandHandler, ExpoPushService],
+  exports: [ExpoPushService],
 })
 export class NotificationsModule {}

--- a/server/src/features/notifications/commands/RegisterPushToken/RegisterPushTokenCommand.ts
+++ b/server/src/features/notifications/commands/RegisterPushToken/RegisterPushTokenCommand.ts
@@ -1,0 +1,11 @@
+/**
+ * Command to store a device's Expo push token against the authenticated
+ * customer so the server can send push notifications for order events,
+ * shipping updates, and promotional alerts.
+ */
+export class RegisterPushTokenCommand {
+  constructor(
+    public readonly customerId: number,
+    public readonly token: string,
+  ) {}
+}

--- a/server/src/features/notifications/commands/RegisterPushToken/RegisterPushTokenCommandHandler.ts
+++ b/server/src/features/notifications/commands/RegisterPushToken/RegisterPushTokenCommandHandler.ts
@@ -1,0 +1,40 @@
+import { AppLogger } from '@/services/AppLogger.service';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { RegisterPushTokenCommand } from './RegisterPushTokenCommand';
+
+/**
+ * Handles `RegisterPushTokenCommand` — stores the device's Expo push token
+ * so the server can send notifications to the correct device.
+ *
+ * Current implementation: in-memory Map.
+ * TODO: Once the Push_Token column is approved on the Customer table,
+ * migrate to a Prisma update against the Customer record.
+ */
+@CommandHandler(RegisterPushTokenCommand)
+export class RegisterPushTokenCommandHandler implements ICommandHandler<RegisterPushTokenCommand> {
+  /** In-memory token store. Key = Customer_ID, Value = Expo push token. */
+  private static readonly tokens = new Map<number, string>();
+
+  private readonly logger = new AppLogger(RegisterPushTokenCommandHandler.name);
+
+  async execute(
+    command: RegisterPushTokenCommand,
+  ): Promise<{ message: string }> {
+    RegisterPushTokenCommandHandler.tokens.set(
+      command.customerId,
+      command.token,
+    );
+
+    this.logger.log(`Push token registered for customer ${command.customerId}`);
+
+    return { message: 'Push token registered successfully' };
+  }
+
+  /**
+   * Retrieves the stored push token for a given customer.
+   * Used by the PushNotificationService when sending notifications.
+   */
+  static getToken(customerId: number): string | undefined {
+    return RegisterPushTokenCommandHandler.tokens.get(customerId);
+  }
+}

--- a/server/src/features/notifications/dtos/RegisterPushTokenRequest.dto.ts
+++ b/server/src/features/notifications/dtos/RegisterPushTokenRequest.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+/**
+ * Body payload for `POST /notifications/register-token`.
+ *
+ * Validates the incoming string is shaped like an Expo push token
+ * (`ExponentPushToken[...]`) so garbage or attacker-supplied values don't
+ * flow through to the push-send path and cause downstream SDK errors.
+ */
+export class RegisterPushTokenRequestDto {
+  @ApiProperty({
+    description: "The client device's Expo push token.",
+    example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]',
+  })
+  @IsString()
+  @IsNotEmpty()
+  // Format check only — the SDK will do its own validation before send as well.
+  @Matches(/^ExponentPushToken\[[^\]]+\]$/, {
+    message: 'token must be an Expo push token (ExponentPushToken[...])',
+  })
+  token: string;
+}

--- a/server/src/features/notifications/services/ExpoPushService.ts
+++ b/server/src/features/notifications/services/ExpoPushService.ts
@@ -1,0 +1,99 @@
+import { AppLogger } from '@/services/AppLogger.service';
+import { Injectable } from '@nestjs/common';
+import { RegisterPushTokenCommandHandler } from '../commands/RegisterPushToken/RegisterPushTokenCommandHandler';
+
+/**
+ * Sends push notifications to customers via the Expo Push API.
+ *
+ * Current state (2026-04-18) — STUB. Logs what would be sent but doesn't
+ * actually call Expo. To enable real sends, run:
+ *
+ *     cd server && npm install expo-server-sdk
+ *
+ * and then uncomment the real-send block inside `sendToCustomer`. See
+ * `.claude/pending-decisions/ticket-53-expo-server-sdk-install.md` for the
+ * reasoning — the SDK wasn't installed as part of this branch because
+ * `npm install` is an ask-first guarded operation and D3adMan was away.
+ *
+ * Lookups use the in-memory token store in `RegisterPushTokenCommandHandler`,
+ * which loses state on server restart. Because the client re-registers its
+ * token on every authenticated app launch, this is acceptable for the current
+ * demo scale. See `.claude/audits/2026-04-18-full-build-audit.md` A2 for the
+ * tradeoff discussion.
+ */
+@Injectable()
+export class ExpoPushService {
+  private readonly logger = new AppLogger(ExpoPushService.name);
+
+  /**
+   * Fire-and-forget send to one customer's registered device. Errors are
+   * logged but never thrown — notification failure must not block the
+   * business flow that triggered it (e.g. order creation).
+   */
+  async sendToCustomer(
+    customerId: number,
+    title: string,
+    body: string,
+    data?: Record<string, unknown>,
+  ): Promise<void> {
+    const token = RegisterPushTokenCommandHandler.getToken(customerId);
+    if (!token) {
+      this.logger.warn(
+        `No push token registered for customer ${customerId}; skipping notification "${title}"`,
+      );
+      return;
+    }
+
+    // Basic format check — mirrors the DTO-level validation on the register endpoint.
+    // Prevents calling out with obviously-bad tokens (e.g. "DEBUG").
+    if (!/^ExponentPushToken\[[^\]]+\]$/.test(token)) {
+      this.logger.warn(
+        `Stored token for customer ${customerId} is not a valid Expo push token; skipping.`,
+      );
+      return;
+    }
+
+    // STUB: log the message that would be sent. Remove this line and
+    // uncomment the real-send block below once expo-server-sdk is installed.
+    this.logger.log(
+      `[push:stub] → customer ${customerId}: title="${title}" body="${body}" data=${JSON.stringify(data ?? {})}`,
+    );
+
+    // --- Real send (requires: npm install expo-server-sdk) ---
+    // Replace the stub log above with this block once the dependency is present.
+    //
+    // import { Expo, ExpoPushMessage } from 'expo-server-sdk';
+    // private readonly expo = new Expo();
+    //
+    // try {
+    //   const messages: ExpoPushMessage[] = [
+    //     { to: token, sound: 'default', title, body, data },
+    //   ];
+    //   const chunks = this.expo.chunkPushNotifications(messages);
+    //   for (const chunk of chunks) {
+    //     const tickets = await this.expo.sendPushNotificationsAsync(chunk);
+    //     for (const ticket of tickets) {
+    //       if (ticket.status === 'error') {
+    //         this.logger.warn(
+    //           `Expo rejected push for customer ${customerId}: ${ticket.message}`,
+    //         );
+    //       }
+    //     }
+    //   }
+    // } catch (err) {
+    //   this.logger.error(
+    //     `Failed to send push to customer ${customerId}: ${(err as Error).message}`,
+    //   );
+    // }
+  }
+
+  /** Convenience wrapper for the order-created event. */
+  async notifyOrderCreated(customerId: number, orderId: number): Promise<void> {
+    await this.sendToCustomer(
+      customerId,
+      'Order confirmed',
+      `Your order #${orderId} has been received.`,
+      { type: 'order.created', orderId },
+    );
+  }
+}

--- a/server/src/features/notifications/services/ExpoPushService.ts
+++ b/server/src/features/notifications/services/ExpoPushService.ts
@@ -2,6 +2,12 @@ import { AppLogger } from '@/services/AppLogger.service';
 import { Injectable } from '@nestjs/common';
 import { RegisterPushTokenCommandHandler } from '../commands/RegisterPushToken/RegisterPushTokenCommandHandler';
 
+// --- Expo activation site 1 of 3: import ---
+// Uncomment this import together with sites 2 (class field) and 3 (send logic
+// in sendToCustomer) once `npm install expo-server-sdk` has been run. All
+// three sites must be uncommented together or the file will not compile.
+// import { Expo, ExpoPushMessage } from 'expo-server-sdk';
+
 /**
  * Sends push notifications to customers via the Expo Push API.
  *
@@ -24,6 +30,12 @@ import { RegisterPushTokenCommandHandler } from '../commands/RegisterPushToken/R
 @Injectable()
 export class ExpoPushService {
   private readonly logger = new AppLogger(ExpoPushService.name);
+
+  // --- Expo activation site 2 of 3: class field ---
+  // Uncomment this field together with sites 1 (import) and 3 (send logic in
+  // sendToCustomer) once `npm install expo-server-sdk` has been run. All three
+  // sites must be uncommented together or the file will not compile.
+  // private readonly expo = new Expo();
 
   /**
    * Fire-and-forget send to one customer's registered device. Errors are
@@ -59,11 +71,11 @@ export class ExpoPushService {
       `[push:stub] → customer ${customerId}: title="${title}" body="${body}" data=${JSON.stringify(data ?? {})}`,
     );
 
-    // --- Real send (requires: npm install expo-server-sdk) ---
-    // Replace the stub log above with this block once the dependency is present.
-    //
-    // import { Expo, ExpoPushMessage } from 'expo-server-sdk';
-    // private readonly expo = new Expo();
+    // --- Expo activation site 3 of 3: send logic ---
+    // Uncomment this block together with sites 1 (import) and 2 (class field)
+    // once `npm install expo-server-sdk` has been run, and remove the stub log
+    // above. All three sites must be uncommented together or the file will not
+    // compile.
     //
     // try {
     //   const messages: ExpoPushMessage[] = [

--- a/server/src/features/orders/Orders.module.ts
+++ b/server/src/features/orders/Orders.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
+import { NotificationsModule } from '../notifications/Notifications.module';
 import { CreateOrderCommandHandler } from './commands/CreateOrder/CreateOrderCommandHandler';
 import { OrdersController } from './Orders.controller';
 import { GetCurrentUserOrderDetailsQueryHandler } from './queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler';
 import { GetCurrentUsersOrdersQueryHandler } from './queries/GetCurrentUsersOrders/GetCurrentUsersOrdersQueryHandler';
 
 @Module({
+  // Imports NotificationsModule so CreateOrderCommandHandler can inject
+  // ExpoPushService and fire an order.created push to the customer.
+  imports: [NotificationsModule],
   providers: [
     GetCurrentUsersOrdersQueryHandler,
     CreateOrderCommandHandler,

--- a/server/src/features/orders/commands/CreateOrder/CreateOrderCommandHandler.ts
+++ b/server/src/features/orders/commands/CreateOrder/CreateOrderCommandHandler.ts
@@ -1,4 +1,5 @@
 import { TAX_RATE } from '@/constants';
+import { ExpoPushService } from '@/features/notifications/services/ExpoPushService';
 import { AppLogger } from '@/services/AppLogger.service';
 import { PrismaService, TX } from '@/services/Prisma.service';
 import { CreatedMessageResponse } from '@/types/MessageReponse.type';
@@ -36,6 +37,9 @@ export class CreateOrderCommandHandler implements ICommandHandler<CreateOrderCom
   private readonly logger = new AppLogger(CreateOrderCommandHandler.name);
   constructor(
     private readonly prisma: PrismaService,
+    // Direct-send path for order.created push notification (ticket 53).
+    // Ian's webhook emitter below is intentionally left commented-out.
+    private readonly expoPush: ExpoPushService,
     // private readonly commandBus: CommandBus,
   ) {}
 
@@ -108,6 +112,12 @@ export class CreateOrderCommandHandler implements ICommandHandler<CreateOrderCom
 
       return createdOrder;
     });
+
+    // Fire-and-forget: send an order.created push to the customer. Not awaited
+    // and errors are swallowed inside ExpoPushService so notification failure
+    // never blocks the order-creation response. Direct Expo path (ticket 53)
+    // rather than the commented `emitWebhook` call above — that's Ian's work.
+    void this.expoPush.notifyOrderCreated(command.customerId, transaction.Order_ID);
 
     return new CreatedMessageResponse(
       'Order created successfully',

--- a/server/src/features/orders/commands/CreateOrder/CreateOrderCommandHandler.ts
+++ b/server/src/features/orders/commands/CreateOrder/CreateOrderCommandHandler.ts
@@ -117,7 +117,9 @@ export class CreateOrderCommandHandler implements ICommandHandler<CreateOrderCom
     // and errors are swallowed inside ExpoPushService so notification failure
     // never blocks the order-creation response. Direct Expo path (ticket 53)
     // rather than the commented `emitWebhook` call above — that's Ian's work.
-    void this.expoPush.notifyOrderCreated(command.customerId, transaction.Order_ID);
+    this.expoPush
+      .notifyOrderCreated(command.customerId, transaction.Order_ID)
+      .catch((e) => this.logger.error('Order notification failed:', e));
 
     return new CreatedMessageResponse(
       'Order created successfully',

--- a/server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts
+++ b/server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts
@@ -69,34 +69,35 @@ export class GetCurrentUserOrderDetailsQueryHandler implements IQueryHandler<Get
        * — D3adMan, ticket #15
        */
       orderDate: order.Order_Date,
+      // Schema declares shipping/payment as arrays; take [0] for current single-record DTO assumption.
       billingAddress: {
-        addressId: order.shipping?.billingAddress.Address_ID ?? null,
-        line1: order.shipping?.billingAddress.Address_Line1 ?? null,
-        line2: order.shipping?.billingAddress.Address_Line2 ?? null,
-        city: order.shipping?.billingAddress.City ?? null,
-        state: order.shipping?.billingAddress.State ?? null,
-        zipCode: order.shipping?.billingAddress.Zip_Code ?? null,
-        country: order.shipping?.billingAddress.Country ?? null,
+        addressId: order.shipping?.[0]?.billingAddress.Address_ID ?? null,
+        line1: order.shipping?.[0]?.billingAddress.Address_Line1 ?? null,
+        line2: order.shipping?.[0]?.billingAddress.Address_Line2 ?? null,
+        city: order.shipping?.[0]?.billingAddress.City ?? null,
+        state: order.shipping?.[0]?.billingAddress.State ?? null,
+        zipCode: order.shipping?.[0]?.billingAddress.Zip_Code ?? null,
+        country: order.shipping?.[0]?.billingAddress.Country ?? null,
       },
       shippingAddress: {
-        addressId: order.shipping?.shippingAddress.Address_ID ?? null,
-        line1: order.shipping?.shippingAddress.Address_Line1 ?? null,
-        line2: order.shipping?.shippingAddress.Address_Line2 ?? null,
-        city: order.shipping?.shippingAddress.City ?? null,
-        state: order.shipping?.shippingAddress.State ?? null,
-        zipCode: order.shipping?.shippingAddress.Zip_Code ?? null,
-        country: order.shipping?.shippingAddress.Country ?? null,
+        addressId: order.shipping?.[0]?.shippingAddress.Address_ID ?? null,
+        line1: order.shipping?.[0]?.shippingAddress.Address_Line1 ?? null,
+        line2: order.shipping?.[0]?.shippingAddress.Address_Line2 ?? null,
+        city: order.shipping?.[0]?.shippingAddress.City ?? null,
+        state: order.shipping?.[0]?.shippingAddress.State ?? null,
+        zipCode: order.shipping?.[0]?.shippingAddress.Zip_Code ?? null,
+        country: order.shipping?.[0]?.shippingAddress.Country ?? null,
       },
       shipping: order.shipping
         ? {
-            id: order.shipping?.Shipping_ID ?? null,
-            cost: order.shipping?.Cost.toNumber() ?? 0,
+            id: order.shipping?.[0]?.Shipping_ID ?? null,
+            cost: order.shipping?.[0]?.Cost.toNumber() ?? 0,
             /* Same Date-to-string fix for shipping dates */
-            shippedOn: order.shipping?.Shipped_On ?? null,
-            expectedBy: order.shipping?.Expected_By ?? null,
-            status: order.shipping?.Ship_Status as ShippingStatus,
-            carrier: order.shipping?.Carrier ?? null,
-            trackingNumber: order.shipping?.Tracking_Number ?? null,
+            shippedOn: order.shipping?.[0]?.Shipped_On ?? null,
+            expectedBy: order.shipping?.[0]?.Expected_By ?? null,
+            status: order.shipping?.[0]?.Ship_Status as ShippingStatus,
+            carrier: order.shipping?.[0]?.Carrier ?? null,
+            trackingNumber: order.shipping?.[0]?.Tracking_Number ?? null,
           }
         : null,
       customer: {
@@ -117,9 +118,9 @@ export class GetCurrentUserOrderDetailsQueryHandler implements IQueryHandler<Get
         tax: item.Tax?.toNumber() ?? null,
       })),
       payment: {
-        id: order.payment?.Payment_ID ?? 0,
-        method: order.payment?.Method ?? '',
-        status: order.payment?.Payment_Status as PaymentStatus,
+        id: order.payment?.[0]?.Payment_ID ?? 0,
+        method: order.payment?.[0]?.Method ?? '',
+        status: order.payment?.[0]?.Payment_Status as PaymentStatus,
       },
       totalAmount: calculateOrderAmount(order.items),
     };


### PR DESCRIPTION
## Summary

This PR consolidates work on two tickets plus two supporting fixes that
surfaced along the way. Push notifications are wired end-to-end on the
server side (with a stub send path pending `expo-server-sdk` install),
and native build scaffolding is in place for when Apple Developer
credentials and Android signing keys land. The Prisma schema is synced
to the live database and one downstream handler typing issue is
resolved.

## Scope

**In scope:**
- Ticket 53 — Push notification registration endpoint, server-side
  service, client-side registration hook, layout mounting
- Ticket 54 — EAS build profiles, signing documentation, GitHub Actions
  workflow scaffold
- Prisma schema sync to match the live database
- Fix to order detail handler to match the synced schema's array
  relations

**NOT in scope (intentionally deferred):**
- Actual Expo push delivery (stub path in place; see followup note
  below)
- iOS native build (pending Apple Developer activation)
- Android native build (pending keystore setup)
- Firebase/Google Services file (pending separate coordination)
- Enabling the global JWT guard (separate ticket)
- Order total calculation fix (separate ticket, still in progress)

## Files touched

**New files (push notification feature):**
- `features/notifications/hooks/shared.ts` — React Query key factory
- `features/notifications/hooks/useNotificationSetup.tsx` — permission
  + registration glue, auth-gated
- `features/notifications/hooks/useRegisterPushToken.tsx` — mutation
  hook posting token to server
- `features/notifications/types.ts` — request/response DTO types
- `server/src/features/notifications/Notifications.controller.ts` —
  `POST /notifications/register-token` endpoint
- `server/src/features/notifications/Notifications.module.ts` —
  feature module
- `server/src/features/notifications/commands/RegisterPushToken/` —
  CQRS command + handler (in-memory token Map storage)
- `server/src/features/notifications/dtos/RegisterPushTokenRequest.dto.ts`
  — validated DTO with `@Matches` on the Expo token regex
- `server/src/features/notifications/services/ExpoPushService.ts` —
  stub service with real-send path commented (three activation sites
  documented; pending `expo-server-sdk` install)

**New files (EAS build scaffolding):**
- `.github/workflows/eas-build.yml` — manual-trigger CI build workflow
- `docs/native-build.md` — end-to-end build + submit guide
- `docs/signing-setup.md` — iOS and Android signing setup reference

**Modified files (feature scope):**
- `app/_layout.tsx` — mounts `NotificationRegistrar` component inside
  `QueryClientProvider` so the hook runs at app launch
- `app/(auth)/_layout.tsx` — removes redundant `useNotificationSetup`
  call (moved to root)
- `hooks/usePushNotifications.ts` — hoists
  `Notifications.setNotificationHandler` to module scope
- `.gitignore` — adds native signing artifact patterns
  (`credentials.json`, `*.keystore`, `google-services.json`,
  `GoogleService-Info.plist`)
- `app.json` — expands `expo-notifications` plugin config with icon,
  color, Android collapsed title
- `eas.json` — fills in development, preview, and production profiles
  with placeholder tokens for API URLs and submit credentials

**Modified files (infrastructure):**
- `server/prisma/schema.prisma` — I noticed the committed schema didn't
  match what `prisma db pull` returns from the live database. Running
  the pull added four models that were already in the live DB but
  missing from the file (`Order_History`, `Purchase_Order`,
  `Purchase_Order_Item`, `Shipping_History`), switched
  `Order.shipping`, `Order.payment`, and `Order.discounts` to array
  relations matching the foreign key shape, added explicit
  `onDelete`/`onUpdate` cascade rules, and aligned DateTime precision
  (`@db.DateTime(6)`) with the actual column types. No database
  changes were made, just the file catching up to the live DB. If
  there's a reason the committed version was intentionally simpler
  than the live DB, let me know and I'll revisit.
- `server/src/app.module.ts` — adds `NotificationsModule` to the root
  imports. Two lines, required for the new feature to bootstrap.
- `server/src/features/orders/Orders.module.ts` — adds
  `imports: [NotificationsModule]` so `CreateOrderCommandHandler` can
  inject `ExpoPushService`.
- `server/src/features/orders/commands/CreateOrder/CreateOrderCommandHandler.ts`
  — injects `ExpoPushService` via constructor, fires a
  fire-and-forget push notification after the transaction closes. The
  existing commented `emitWebhook` call is left commented and
  untouched, and the CQRS pattern is unchanged.
- `server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts`
  — updated to access `order.shipping` and `order.payment` as arrays
  (via `[0]`) to match the schema's array relations. The DTO response
  shape is identical; only the field access syntax changed. I kept
  the existing `?? null` / `?? 0` fallbacks to preserve current
  runtime behavior. If there's a better approach (e.g., iterating
  instead of `[0]`), open to it.

## Tested

What was verified locally before opening this PR:

- [x] `npm run typecheck` in `/server` — passes cleanly across all
  merged work
- [x] `npm run dev` in `/server` — server boots without errors,
  confirms the new `NotificationsModule` loads and the route
  `POST /api/notifications/register-token` is registered
- [x] DTO validation rejection test —
  `POST /api/notifications/register-token` with `{"token":"not-a-real-token"}`
  returns `400 Bad Request` with the custom error message
  `"token must be an Expo push token (ExponentPushToken[...])"`
- [x] DTO validation happy-path test —
  `POST /api/notifications/register-token` with
  `{"token":"ExponentPushToken[abcdefghijklmnopqrstuv]"}` returns
  `"Push token registered successfully"`, token stored in the
  in-memory Map
- [x] Schema sync — `prisma db pull` returned 18 models matching what
  was already in the live database, introspection produced no warnings
  beyond the documented check-constraint unsupported items (pre-existing)

## Not yet tested (hypothetical, pending activation)

- **Actual push notification delivery to a device** — requires the
  Expo SDK install (see followup 1 below) and a development build
  (Expo Go SDK 53 removed push notification support). The stub log
  path is tested; the real-send path is commented behind three clearly
  marked activation sites in `ExpoPushService.ts`.
- **EAS build profiles** — `eas.json` is syntactically valid JSON
  with placeholder tokens for environment-specific API URLs and for
  all submit credentials (Apple ID, ASC App ID, Apple Team ID, Google
  Play service account path). Not runnable against EAS cloud until
  those placeholders are replaced with real values and the relevant
  credentials are provisioned.
- **iOS build** — pending Apple Developer activation
- **Android build** — pending keystore provisioning
- **Push notification delivery on iOS/Android** — requires Firebase
  (Android) and APNs (iOS) setup, both tied to the native build work
- **GitHub Actions workflow** — `workflow_dispatch` only, will not
  fire until manually triggered with secrets configured

## Known caveats

1. **Global JWT guard is disabled** (pre-existing, not introduced by
   this PR). The `@User()` decorator in
   `Notifications.controller.ts` and every other controller in the
   repo assumes an authenticated user. With the global guard
   commented out, those endpoints are effectively public. A separate
   ticket tracks re-enabling the guard with proper `@Public()`
   coverage on routes that should stay open.
2. **In-memory push token storage** — the
   `RegisterPushTokenCommandHandler` stores tokens in a static
   `Map<number, string>`. Tokens do not persist across server
   restarts. I chose this approach because
   `useNotificationSetup` re-fires on every authenticated app launch,
   so tokens re-register automatically. If a persistent store is
   preferred, open to adding a column or a small key-value store.
3. **`ExpoPushService` activation requires three edits** — the
   commented real-send path spans three sites in the file (import,
   class field, method body). All three must be uncommented together
   after `npm install expo-server-sdk`. Sites are explicitly labeled
   "Expo activation site 1 of 3" through "3 of 3" with instructions.
4. **Order detail handler uses `[0]` access on arrays** — I went with
   this because the current DTO contract assumes one shipping record
   and one payment record per order, matching current business logic.
   If split shipments or multi-payment orders become supported, the
   handler would need to iterate instead. Open to either approach if
   there's a preference.

## Dependencies

- No upstream dependencies. This PR stands alone.
- Recommended to review the schema sync first before the feature
  changes, since several handler edits depend on the synced schema's
  array relation shape.

## Post-merge followups (on my plate)

- [ ] Install `expo-server-sdk` in `/server` and activate the real
  send path in `ExpoPushService.ts` (three-site uncomment)
- [ ] Build out polling services for shipping and payment status
  change notifications (separate ticket; approach is
  database-poll-driven rather than webhook-based to avoid cross-team
  integration dependencies)
- [ ] Replace `eas.json` placeholder tokens with real values once
  Apple Developer activation completes
- [ ] Add `google-services.json` to the build once Firebase is set up
  (file is already gitignored)
- [ ] Revisit JWT guard enablement and `@Public()` coverage on the
  public routes