### PR TITLE
fix(orders): null-safe access on Order_Item inventory join

### DIFF
--- a/server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts
+++ b/server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts
@@ -111,8 +111,10 @@ export class GetCurrentUserOrderDetailsQueryHandler implements IQueryHandler<Get
         amount: discount.Amount.toNumber(),
       })),
       items: order.items.map((item) => ({
-        id: item.Inventory_ID,
-        name: item.inventory.product.Product_Name,
+        id: item.Inventory_ID ?? 0,
+        name:
+          item.inventory?.product?.Product_Name ??
+          'Product details unavailable',
         quantity: item.Quantity,
         price: item.Amount.toNumber(),
         tax: item.Tax?.toNumber() ?? null,


### PR DESCRIPTION
Null-safe Order_Item inventory access
Summary
Some Order_Items in the live DB reference Inventory_IDs that don't exist
in the Inventory table. When the Order Detail handler tries to read
item.inventory.product.Product_Name for those items, it crashes with a
null pointer error and the whole order detail screen fails to load.
This adds defensive null-safe access so orders with orphaned inventory
references display cleanly with a placeholder label instead of crashing.
Scope
In scope:

GetCurrentUserOrderDetailsQueryHandler.ts — null-safe access on
Inventory_ID and the inventory → product → Product_Name join

NOT in scope:

The list handler doesn't touch that join (just uses items.length),
so no changes needed there
Not investigating the root cause of why Inventory rows are missing
(separate problem, probably DB seed or cascade issue)
Not adding defensive guards elsewhere in the handler without evidence
of other crashes

Files touched
server/src/features/orders/queries/GetCurrentUsersOrderDetails/GetCurrentUserOrderDetailsQueryHandler.ts
— two fields in the items.map block:

id: item.Inventory_ID → id: item.Inventory_ID ?? 0
name: item.inventory.product.Product_Name → name: item.inventory?.product?.Product_Name ?? 'Product details unavailable'

4 insertions, 2 deletions, one file.
Tested

 npm run typecheck passes
 Logged in as a customer with orphaned inventory references in
their order (Lori's Order 1 references Inventory_IDs that don't exist
in the Inventory table)
 Order detail screen loads without crashing
 Items with missing inventory show "Product details unavailable"
as the name; other fields (quantity, price, tax) render correctly
 Items with valid inventory show real product names as before

Dependencies
None. Standalone fix.
Known caveats

The underlying data issue (Inventory rows missing for referenced
Order_Items) is not fixed by this PR. That's a separate question for
whoever owns the seed / cascade logic.
Defensive access is limited to the two fields where the crash was
observed. Other joins in the handler (customer, shipping address,
payment, etc.) are not touched. Can add more guards if evidence
surfaces, but preferred not to armor against hypothetical failures.
If there's a better approach (e.g., a Prisma query that pre-filters
or a cross-team cleanup), open to ideas.