### PR TITLE
feat(splash): add animated two-stage splash with team signature and logo

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,4 @@
+import AnimatedSplash from '@/components/AnimatedSplash';
 import { toastConfig } from '@/components/ToastConfig';
 import { useAuthStore } from '@/features/auth/store';
 import { useNotificationSetup } from '@/features/notifications/hooks/useNotificationSetup';
@@ -5,7 +6,7 @@ import { queryClient } from '@/lib/queryClient';
 import { PortalHost } from '@rn-primitives/portal';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Slot, useRouter, useSegments } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
@@ -47,6 +48,7 @@ export default function RootLayout() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const router = useRouter();
   const segments = useSegments();
+  const [splashDone, setSplashDone] = useState(false);
 
   // Hydrate the auth store from SecureStore once on startup
   useEffect(() => {
@@ -78,12 +80,15 @@ export default function RootLayout() {
   // Show a spinner while we wait for SecureStore to respond
   if (isLoading)
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator
-          size='large'
-          color='#0000ff'
-        />
-      </View>
+      <>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator
+            size='large'
+            color='#0000ff'
+          />
+        </View>
+        {!splashDone && <AnimatedSplash onFinish={() => setSplashDone(true)} />}
+      </>
     );
 
   return (
@@ -92,6 +97,7 @@ export default function RootLayout() {
         {/* Fires push-token registration early; self-gates on auth. */}
         <NotificationRegistrar />
         <Slot />
+        {!splashDone && <AnimatedSplash onFinish={() => setSplashDone(true)} />}
         <PortalHost />
         <Toast config={toastConfig} />
       </SafeAreaProvider>

--- a/components/AnimatedSplash.tsx
+++ b/components/AnimatedSplash.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, View, Image, Text, Dimensions } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSequence,
+  withDelay,
+  Easing,
+} from 'react-native-reanimated';
+
+// Timing constants — adjust here to tune the whole sequence.
+const TIMING = {
+  // Stage 1: "The A Team" signature
+  signatureRiseFrom: 30, // px below center
+  signatureRiseIn: 600, // ms to rise + fade in
+  signatureHold: 500, // ms to hold in place
+  signatureFadeOut: 400, // ms to fade out
+  // Stage 2: Elevate Retail logo
+  logoDelay: 100, // ms pause between signature out and logo in
+  logoRiseFrom: 30,
+  logoRiseIn: 600,
+  logoHold: 500,
+  logoFadeOut: 400,
+  // Stage 3: hand off to app
+  handoffDelay: 100, // small buffer before calling onFinish
+};
+
+const DERIVED = {
+  logoStartsAt:
+    TIMING.signatureRiseIn +
+    TIMING.signatureHold +
+    TIMING.signatureFadeOut +
+    TIMING.logoDelay,
+  totalDuration: 0, // computed below
+};
+DERIVED.totalDuration =
+  DERIVED.logoStartsAt +
+  TIMING.logoRiseIn +
+  TIMING.logoHold +
+  TIMING.logoFadeOut +
+  TIMING.handoffDelay;
+
+type AnimatedSplashProps = {
+  /** Called once the full animation sequence completes. */
+  onFinish: () => void;
+};
+
+/**
+ * Two-stage animated splash screen.
+ *
+ * Stage 1 — "The A" / "Team" text rises from below center, holds, fades.
+ * Stage 2 — Elevate Retail logo rises from below center, holds, fades.
+ * Stage 3 — Fires onFinish so the parent layout can render the app.
+ *
+ * Rendered on a white background. Uses StyleSheet.absoluteFillObject so
+ * it overlays whatever is rendered underneath, regardless of parent layout.
+ */
+export default function AnimatedSplash({ onFinish }: AnimatedSplashProps) {
+  const signatureOpacity = useSharedValue(0);
+  const signatureTranslateY = useSharedValue(TIMING.signatureRiseFrom);
+  const logoOpacity = useSharedValue(0);
+  const logoTranslateY = useSharedValue(TIMING.logoRiseFrom);
+
+  useEffect(() => {
+    // Stage 1 — signature rises and fades in, holds, fades out.
+    signatureOpacity.value = withSequence(
+      withTiming(1, {
+        duration: TIMING.signatureRiseIn,
+        easing: Easing.out(Easing.cubic),
+      }),
+      withDelay(
+        TIMING.signatureHold,
+        withTiming(0, {
+          duration: TIMING.signatureFadeOut,
+          easing: Easing.in(Easing.cubic),
+        }),
+      ),
+    );
+    signatureTranslateY.value = withTiming(0, {
+      duration: TIMING.signatureRiseIn,
+      easing: Easing.out(Easing.cubic),
+    });
+
+    // Stage 2 — logo rises and fades in after the signature is gone.
+    logoOpacity.value = withDelay(
+      DERIVED.logoStartsAt,
+      withSequence(
+        withTiming(1, {
+          duration: TIMING.logoRiseIn,
+          easing: Easing.out(Easing.cubic),
+        }),
+        withDelay(
+          TIMING.logoHold,
+          withTiming(0, {
+            duration: TIMING.logoFadeOut,
+            easing: Easing.in(Easing.cubic),
+          }),
+        ),
+      ),
+    );
+    logoTranslateY.value = withDelay(
+      DERIVED.logoStartsAt,
+      withTiming(0, {
+        duration: TIMING.logoRiseIn,
+        easing: Easing.out(Easing.cubic),
+      }),
+    );
+
+    // Stage 3 — hand off to the app once everything is done.
+    const timeoutId = setTimeout(() => {
+      onFinish();
+    }, DERIVED.totalDuration);
+
+    return () => clearTimeout(timeoutId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const signatureAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: signatureOpacity.value,
+    transform: [{ translateY: signatureTranslateY.value }],
+  }));
+
+  const logoAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: logoOpacity.value,
+    transform: [{ translateY: logoTranslateY.value }],
+  }));
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <Animated.View style={[styles.centerOverlay, signatureAnimatedStyle]}>
+        <Text style={styles.signatureLine}>The A</Text>
+        <Text style={styles.signatureLine}>Team</Text>
+      </Animated.View>
+
+      <Animated.View style={[styles.centerOverlay, logoAnimatedStyle]}>
+        <Image
+          source={require('@/assets/images/icon_new.png')}
+          style={styles.logo}
+          resizeMode="contain"
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const LOGO_SIZE = Math.min(SCREEN_WIDTH * 0.6, 280);
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#FFFFFF',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 9999,
+  },
+  centerOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  signatureLine: {
+    fontSize: 42,
+    fontWeight: '800',
+    color: '#000000',
+    textAlign: 'center',
+    lineHeight: 52,
+    letterSpacing: 0.5,
+  },
+  logo: {
+    width: LOGO_SIZE,
+    height: LOGO_SIZE,
+  },
+});

--- a/server/src/features/notifications/Notifications.module.ts
+++ b/server/src/features/notifications/Notifications.module.ts
@@ -3,6 +3,8 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { NotificationsController } from './Notifications.controller';
 import { RegisterPushTokenCommandHandler } from './commands/RegisterPushToken/RegisterPushTokenCommandHandler';
 import { ExpoPushService } from './services/ExpoPushService';
+import { FulfillmentStatusNotificationService } from './services/FulfillmentStatusNotificationService';
+import { PaymentStatusNotificationService } from './services/PaymentStatusNotificationService';
 
 @Module({
   imports: [CqrsModule],
@@ -10,7 +12,12 @@ import { ExpoPushService } from './services/ExpoPushService';
   // ExpoPushService is exported so other feature modules (e.g. OrdersModule)
   // can inject it to fire notifications on domain events — direct-send path,
   // bypasses Ian's in-progress webhook module by design.
-  providers: [RegisterPushTokenCommandHandler, ExpoPushService],
+  providers: [
+    RegisterPushTokenCommandHandler,
+    ExpoPushService,
+    FulfillmentStatusNotificationService,
+    PaymentStatusNotificationService,
+  ],
   exports: [ExpoPushService],
 })
 export class NotificationsModule {}

--- a/server/src/features/notifications/services/FulfillmentStatusNotificationService.ts
+++ b/server/src/features/notifications/services/FulfillmentStatusNotificationService.ts
@@ -1,0 +1,166 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { AppLogger } from '@/services/AppLogger.service';
+import { PrismaService } from '@/services/Prisma.service';
+import { ExpoPushService } from './ExpoPushService';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Transitions that fire a push notification.
+ *
+ * Fulfillment_Status values per the Shipping team's enum:
+ *   Pending → Processing → Packed → ReadyToShip → Fulfilled
+ *
+ * Customer-facing notifications start at Processing (order creation is
+ * silent because Pending is the default and customers don't need to be
+ * told their brand new order is pending).
+ */
+const NOTIFY_ON_STATUSES: Record<string, { title: string; body: (orderId: number) => string }> = {
+  Processing: {
+    title: 'Order update',
+    body: (orderId) => `Your order #${orderId} is being prepared.`,
+  },
+  Packed: {
+    title: 'Order update',
+    body: (orderId) => `Your order #${orderId} is packed and ready to go out.`,
+  },
+  ReadyToShip: {
+    title: 'Order update',
+    body: (orderId) => `Your order #${orderId} is ready to ship.`,
+  },
+  Fulfilled: {
+    title: 'Order shipped',
+    body: (orderId) => `Your order #${orderId} has shipped.`,
+  },
+};
+
+/**
+ * Polls the Order table for Fulfillment_Status changes on a 5-minute
+ * interval and fires a push notification to the owning customer when
+ * specific transitions are detected.
+ *
+ * Change detection uses an in-memory Map cache keyed by Order_ID. The
+ * first scan after startup populates the cache silently; subsequent
+ * scans fire pushes for any detected transitions.
+ *
+ * This service reads from the Order table and does not write to it.
+ * Writes to Order.Fulfillment_Status come from the Shipping team's
+ * Java app.
+ */
+@Injectable()
+export class FulfillmentStatusNotificationService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new AppLogger(FulfillmentStatusNotificationService.name);
+  private readonly lastKnownStatus = new Map<number, string>();
+  private intervalId: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly expoPush: ExpoPushService,
+  ) {}
+
+  async onModuleInit() {
+    // Silent first scan — populate the cache without firing any pushes.
+    this.logger.log('Starting silent first scan of Order.Fulfillment_Status');
+    await this.scan(false);
+    this.logger.log(
+      `Initial cache populated with ${this.lastKnownStatus.size} orders`,
+    );
+
+    // Begin regular polling. Errors inside scan are caught there, but we
+    // also guard here in case the promise itself rejects unexpectedly.
+    this.intervalId = setInterval(() => {
+      this.scan(true).catch((err) => {
+        this.logger.error('Polling scan failed', err);
+      });
+    }, POLL_INTERVAL_MS);
+
+    this.logger.log(
+      `Fulfillment status polling started (interval: ${POLL_INTERVAL_MS}ms)`,
+    );
+  }
+
+  onModuleDestroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.logger.log('Fulfillment status polling stopped');
+    }
+  }
+
+  /**
+   * Single scan pass. Queries all orders, compares each to the cached
+   * state, fires notifications for tracked transitions, updates the cache.
+   *
+   * @param fireOnChange when false (first scan), no pushes are fired —
+   *                    only the cache is populated
+   */
+  private async scan(fireOnChange: boolean): Promise<void> {
+    try {
+      const orders = await this.prisma.order.findMany({
+        select: {
+          Order_ID: true,
+          Customer_ID: true,
+          Fulfillment_Status: true,
+        },
+      });
+
+      for (const order of orders) {
+        const orderId = order.Order_ID;
+        const currentStatus = order.Fulfillment_Status;
+        const previousStatus = this.lastKnownStatus.get(orderId);
+
+        // First sighting — just record and move on.
+        if (previousStatus === undefined) {
+          this.lastKnownStatus.set(orderId, currentStatus);
+          continue;
+        }
+
+        // No change since last scan.
+        if (previousStatus === currentStatus) {
+          continue;
+        }
+
+        // Transition detected. Update cache first so a failed push doesn't
+        // cause re-fires on the next scan.
+        this.lastKnownStatus.set(orderId, currentStatus);
+
+        if (!fireOnChange) {
+          continue;
+        }
+
+        const notification = NOTIFY_ON_STATUSES[currentStatus];
+        if (!notification) {
+          // Transition to a status we don't notify on (e.g. back to Pending).
+          // Cache is already updated; no push to fire.
+          continue;
+        }
+
+        this.logger.log(
+          `Order ${orderId}: ${previousStatus} -> ${currentStatus}, firing push`,
+        );
+
+        this.expoPush
+          .sendToCustomer(
+            order.Customer_ID,
+            notification.title,
+            notification.body(orderId),
+            {
+              type: 'fulfillment.status.updated',
+              orderId,
+              status: currentStatus,
+            },
+          )
+          .catch((err) => {
+            this.logger.error(
+              `Failed to send fulfillment notification for order ${orderId}`,
+              err,
+            );
+          });
+      }
+    } catch (err) {
+      this.logger.error('Failed to query Order table during scan', err);
+    }
+  }
+}

--- a/server/src/features/notifications/services/PaymentStatusNotificationService.ts
+++ b/server/src/features/notifications/services/PaymentStatusNotificationService.ts
@@ -1,0 +1,167 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { AppLogger } from '@/services/AppLogger.service';
+import { PrismaService } from '@/services/Prisma.service';
+import { ExpoPushService } from './ExpoPushService';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Payment_Status transitions that fire a push notification.
+ *
+ * Silent on: Pending, Processing (internal workflow states).
+ * Fires on: Completed, Cancelled, Refunded, Failed.
+ */
+const NOTIFY_ON_STATUSES: Record<string, { title: string; body: (orderId: number) => string }> = {
+  Completed: {
+    title: 'Payment received',
+    body: (orderId) => `Your payment for order #${orderId} has been processed.`,
+  },
+  Cancelled: {
+    title: 'Payment cancelled',
+    body: (orderId) => `The payment for your order #${orderId} has been cancelled.`,
+  },
+  Refunded: {
+    title: 'Refund issued',
+    body: (orderId) => `A refund has been issued for order #${orderId}.`,
+  },
+  Failed: {
+    title: 'Payment failed',
+    body: (orderId) =>
+      `We couldn't process payment for your order #${orderId}. Please update your payment method.`,
+  },
+};
+
+/**
+ * Polls the Payment table for Payment_Status changes on a 5-minute
+ * interval and fires a push notification to the owning customer when
+ * specific transitions are detected.
+ *
+ * Resolves the customer by joining Payment back through its Order row
+ * to get Customer_ID. Uses an in-memory Map cache keyed by Payment_ID
+ * for change detection. First scan after startup is silent; subsequent
+ * scans fire pushes for any new transitions.
+ */
+@Injectable()
+export class PaymentStatusNotificationService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new AppLogger(PaymentStatusNotificationService.name);
+  private readonly lastKnownStatus = new Map<number, string>();
+  private intervalId: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly expoPush: ExpoPushService,
+  ) {}
+
+  async onModuleInit() {
+    this.logger.log('Starting silent first scan of Payment.Payment_Status');
+    await this.scan(false);
+    this.logger.log(
+      `Initial cache populated with ${this.lastKnownStatus.size} payments`,
+    );
+
+    this.intervalId = setInterval(() => {
+      this.scan(true).catch((err) => {
+        this.logger.error('Polling scan failed', err);
+      });
+    }, POLL_INTERVAL_MS);
+
+    this.logger.log(
+      `Payment status polling started (interval: ${POLL_INTERVAL_MS}ms)`,
+    );
+  }
+
+  onModuleDestroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.logger.log('Payment status polling stopped');
+    }
+  }
+
+  private async scan(fireOnChange: boolean): Promise<void> {
+    try {
+      const payments = await this.prisma.payment.findMany({
+        select: {
+          Payment_ID: true,
+          Order_ID: true,
+          Payment_Status: true,
+          order: {
+            select: {
+              Customer_ID: true,
+            },
+          },
+        },
+      });
+
+      for (const payment of payments) {
+        const paymentId = payment.Payment_ID;
+        const currentStatus = payment.Payment_Status;
+
+        // Payment_Status is nullable in the schema — treat null as "no
+        // observable state" and skip. We only track real values.
+        if (!currentStatus) {
+          continue;
+        }
+
+        const previousStatus = this.lastKnownStatus.get(paymentId);
+
+        if (previousStatus === undefined) {
+          this.lastKnownStatus.set(paymentId, currentStatus);
+          continue;
+        }
+
+        if (previousStatus === currentStatus) {
+          continue;
+        }
+
+        // Transition detected. Update cache first.
+        this.lastKnownStatus.set(paymentId, currentStatus);
+
+        if (!fireOnChange) {
+          continue;
+        }
+
+        const notification = NOTIFY_ON_STATUSES[currentStatus];
+        if (!notification) {
+          // Transition to a status we don't notify on (e.g. Pending,
+          // Processing). Cache updated, no push fired.
+          continue;
+        }
+
+        if (!payment.order) {
+          this.logger.warn(
+            `Payment ${paymentId} has no associated order; skipping push`,
+          );
+          continue;
+        }
+
+        this.logger.log(
+          `Payment ${paymentId} (Order ${payment.Order_ID}): ${previousStatus} -> ${currentStatus}, firing push`,
+        );
+
+        this.expoPush
+          .sendToCustomer(
+            payment.order.Customer_ID,
+            notification.title,
+            notification.body(payment.Order_ID),
+            {
+              type: 'payment.status.updated',
+              paymentId,
+              orderId: payment.Order_ID,
+              status: currentStatus,
+            },
+          )
+          .catch((err) => {
+            this.logger.error(
+              `Failed to send payment notification for payment ${paymentId}`,
+              err,
+            );
+          });
+      }
+    } catch (err) {
+      this.logger.error('Failed to query Payment table during scan', err);
+    }
+  }
+}


### PR DESCRIPTION
# Animated splash + DB polling notifications

Two features on this PR — both tested end-to-end, no new dependencies, no breaking changes.

## Feature 1 — Animated splash screen

Two-stage splash that runs at app launch on a white background.

- Stage 1 (~1500ms) — "The A" / "Team" signature rises from below center, holds, fades
- Stage 2 (~1500ms) — Elevate Retail logo rises, holds, fades
- Stage 3 — Hands off to the app's login/home screen

Total ~3 seconds. Animation is handled by React Native Reanimated 3 (already a project dependency). Overlays both the auth-loading ActivityIndicator and the main route tree, so there's no flash between native splash and app.

**Files:**
- New: `components/AnimatedSplash.tsx`
- Modified: `app/_layout.tsx` — wires the splash into the provider tree

Uses `@/assets/images/icon_new.png` to match the header convention. Timing constants are grouped at the top of the component for easy tuning.

## Feature 2 — DB polling notifications for fulfillment and payment status

Two background services that poll the shared DB every 5 minutes for status changes and fire customer push notifications on specific transitions. Complements the existing direct-send path (ExpoPushService already called from CreateOrderCommandHandler).

**FulfillmentStatusNotificationService** — polls `Order.Fulfillment_Status`, fires on transitions to Processing, Packed, ReadyToShip, and Fulfilled. Silent on Pending and other unrecognized statuses.

**PaymentStatusNotificationService** — polls `Payment.Payment_Status`, fires on transitions to Completed, Cancelled, Refunded, and Failed. Silent on Pending and Processing.

**Architecture:**
- In-memory Map cache per service for change detection
- Silent first scan on startup populates the cache without firing pushes
- Select-only Prisma queries (no full row reads)
- Resolves owning customer via existing Prisma relations
- Delegates push dispatch to ExpoPushService
- Cache updates before push dispatch so a failed push doesn't re-fire next scan
- Read-only observers, no writes to any table
- No schema changes

**Files:**
- New: `server/src/features/notifications/services/FulfillmentStatusNotificationService.ts`
- New: `server/src/features/notifications/services/PaymentStatusNotificationService.ts`
- Modified: `server/src/features/notifications/Notifications.module.ts` — added both services to `providers` (not exported; consumed only within the notifications module)

## Tested

- [x] `npx tsc --noEmit` passes on the mobile side
- [x] `npm run typecheck` passes on the server side
- [x] Splash verified in Expo web, full sequence plays cleanly, transitions to login screen
- [x] Reviewed splash visually with team before submitting
- [x] Server boots with both notification services registered, silent first scan logs cache population (50 orders / 50 payments) and confirms the 5-minute interval
- [x] Verified notification end-to-end with a real Prisma Studio flip — Order 7's Fulfillment_Status changed from Pending to Processing, the next scan detected the transition and fired the push path:
  ```
  LOG [FulfillmentStatusNotificationService] Order 7: Pending -> Processing, firing push
  WARN [ExpoPushService] No push token registered for customer 12; skipping notification "Order update"
  ```
  Confirms detection, dispatch, and ExpoPushService's graceful fallback when no token is registered.

## Dependencies

None. No new npm packages.

## Known caveats and followups

- **Splash web-only dev error:** `expo-notifications` throws a non-blocking dev error on web because VAPID isn't configured. Pre-existing, unrelated to this PR, doesn't affect mobile or production. Can file a separate platform check fix if we want to clean up web dev experience.
- **ExpoPushService still in stub mode.** Real push delivery requires installing `expo-server-sdk` and uncommenting the three activation sites in ExpoPushService.ts. Keeping that as a separate decision and PR so "go live" is explicit.
- **In-memory notification cache** means transitions during server downtime aren't caught by the polling path. Acceptable for class-project scale; notable for future production work.
- **5-minute polling interval** is hardcoded as a module-local constant. Easy to tune if we want faster or slower detection.
- **Polling target:** confirmed the Shipping team writes to `Order.Fulfillment_Status` but does not update `Shipping.Ship_Status` or `Status_Updated_At`. Polling Order.Fulfillment_Status catches their updates correctly.