### PR TITLE
Skip push registration on web platform

### DIFF
--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,8 +1,8 @@
-import Constants from 'expo-constants';
-import * as Device from 'expo-device';
-import * as Notifications from 'expo-notifications';
-import { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
+import Constants from "expo-constants";
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import { useEffect, useState } from "react";
+import { Platform } from "react-native";
 
 export interface PushNotificationState {
   notification?: Notifications.Notification;
@@ -24,33 +24,39 @@ Notifications.setNotificationHandler({
 });
 
 export const usePushNotifications = (): PushNotificationState => {
-  const [notification, setNotification] = useState<Notifications.Notification | undefined>(
-    undefined,
-  );
-  const [response, setResponse] = useState<Notifications.NotificationResponse | undefined>(
-    undefined,
-  );
-  const [expoPushToken, setExpoPushToken] = useState<Notifications.ExpoPushToken | undefined>(
-    undefined,
-  );
+  const [notification, setNotification] = useState<
+    Notifications.Notification | undefined
+  >(undefined);
+  const [response, setResponse] = useState<
+    Notifications.NotificationResponse | undefined
+  >(undefined);
+  const [expoPushToken, setExpoPushToken] = useState<
+    Notifications.ExpoPushToken | undefined
+  >(undefined);
 
   async function registerForPushNotificationsAsync(): Promise<Notifications.ExpoPushToken | null> {
     let token: Notifications.ExpoPushToken | null = null;
+    if (Platform.OS === "web") {
+      return null;
+    }
     if (!Device.isDevice) {
-      console.warn('ERROR: Must use a physical device or Expo Go on Android emulator');
+      console.warn(
+        "ERROR: Must use a physical device or Expo Go on Android emulator",
+      );
       return null;
     }
 
-    const { status: exisitingStatus } = await Notifications.getPermissionsAsync();
+    const { status: exisitingStatus } =
+      await Notifications.getPermissionsAsync();
     let finalStatus = exisitingStatus;
 
-    if (exisitingStatus !== 'granted') {
+    if (exisitingStatus !== "granted") {
       const { status } = await Notifications.requestPermissionsAsync();
       finalStatus = status;
     }
 
-    if (finalStatus !== 'granted') {
-      alert('Failed to get push token for push notifications!');
+    if (finalStatus !== "granted") {
+      alert("Failed to get push token for push notifications!");
       return null;
     }
 
@@ -58,12 +64,12 @@ export const usePushNotifications = (): PushNotificationState => {
       projectId: Constants.expoConfig?.extra?.eas?.projectId,
     });
 
-    if (Platform.OS === 'android') {
-      Notifications.setNotificationChannelAsync('default', {
-        name: 'default',
+    if (Platform.OS === "android") {
+      Notifications.setNotificationChannelAsync("default", {
+        name: "default",
         importance: Notifications.AndroidImportance.MAX,
         vibrationPattern: [0, 250, 250, 250],
-        lightColor: '#FF231F7C',
+        lightColor: "#FF231F7C",
       });
     }
 
@@ -71,15 +77,20 @@ export const usePushNotifications = (): PushNotificationState => {
   }
 
   useEffect(() => {
-    registerForPushNotificationsAsync().then((token) => setExpoPushToken(token ?? undefined));
+    registerForPushNotificationsAsync().then((token) =>
+      setExpoPushToken(token ?? undefined),
+    );
 
-    const notificationListener = Notifications.addNotificationReceivedListener((notification) => {
-      setNotification(notification);
-    });
+    const notificationListener = Notifications.addNotificationReceivedListener(
+      (notification) => {
+        setNotification(notification);
+      },
+    );
 
-    const responseListener = Notifications.addNotificationResponseReceivedListener((response) => {
-      setResponse(response);
-    });
+    const responseListener =
+      Notifications.addNotificationResponseReceivedListener((response) => {
+        setResponse(response);
+      });
 
     return () => {
       notificationListener.remove();


### PR DESCRIPTION
Adds an early return in usePushNotifications when Platform.OS === 'web'. Eliminates the VAPID subscription error during web dev mode. No behaviour change on iOS or Android.