### PR TITLE
Activate expo-server-sdk for real push delivery

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "dotenv": "^17.3.1",
+        "expo-server-sdk": "^6.1.0",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
         "mssql": "^12.2.1",
@@ -6233,6 +6234,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -6624,6 +6631,20 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expo-server-sdk": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-6.1.0.tgz",
+      "integrity": "sha512-ISuax1AQ7cpM5RAqcu8gVcoLL0ZKskJ5OLoMWmdITBe9nYjTucjdGyBq817YkIvTcj1pAUwx+9toUT7l/V7thA==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1",
+        "undici": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/express": {
@@ -10174,6 +10195,25 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -10458,7 +10498,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11769,6 +11808,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "dotenv": "^17.3.1",
+    "expo-server-sdk": "^6.1.0",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "mssql": "^12.2.1",

--- a/server/src/features/notifications/services/ExpoPushService.ts
+++ b/server/src/features/notifications/services/ExpoPushService.ts
@@ -6,7 +6,7 @@ import { RegisterPushTokenCommandHandler } from '../commands/RegisterPushToken/R
 // Uncomment this import together with sites 2 (class field) and 3 (send logic
 // in sendToCustomer) once `npm install expo-server-sdk` has been run. All
 // three sites must be uncommented together or the file will not compile.
-// import { Expo, ExpoPushMessage } from 'expo-server-sdk';
+import { Expo, ExpoPushMessage } from 'expo-server-sdk';
 
 /**
  * Sends push notifications to customers via the Expo Push API.
@@ -35,7 +35,7 @@ export class ExpoPushService {
   // Uncomment this field together with sites 1 (import) and 3 (send logic in
   // sendToCustomer) once `npm install expo-server-sdk` has been run. All three
   // sites must be uncommented together or the file will not compile.
-  // private readonly expo = new Expo();
+  private readonly expo = new Expo();
 
   /**
    * Fire-and-forget send to one customer's registered device. Errors are
@@ -65,38 +65,26 @@ export class ExpoPushService {
       return;
     }
 
-    // STUB: log the message that would be sent. Remove this line and
-    // uncomment the real-send block below once expo-server-sdk is installed.
-    this.logger.log(
-      `[push:stub] → customer ${customerId}: title="${title}" body="${body}" data=${JSON.stringify(data ?? {})}`,
-    );
-
-    // --- Expo activation site 3 of 3: send logic ---
-    // Uncomment this block together with sites 1 (import) and 2 (class field)
-    // once `npm install expo-server-sdk` has been run, and remove the stub log
-    // above. All three sites must be uncommented together or the file will not
-    // compile.
-    //
-    // try {
-    //   const messages: ExpoPushMessage[] = [
-    //     { to: token, sound: 'default', title, body, data },
-    //   ];
-    //   const chunks = this.expo.chunkPushNotifications(messages);
-    //   for (const chunk of chunks) {
-    //     const tickets = await this.expo.sendPushNotificationsAsync(chunk);
-    //     for (const ticket of tickets) {
-    //       if (ticket.status === 'error') {
-    //         this.logger.warn(
-    //           `Expo rejected push for customer ${customerId}: ${ticket.message}`,
-    //         );
-    //       }
-    //     }
-    //   }
-    // } catch (err) {
-    //   this.logger.error(
-    //     `Failed to send push to customer ${customerId}: ${(err as Error).message}`,
-    //   );
-    // }
+    try {
+      const messages: ExpoPushMessage[] = [
+        { to: token, sound: 'default', title, body, data },
+      ];
+      const chunks = this.expo.chunkPushNotifications(messages);
+      for (const chunk of chunks) {
+        const tickets = await this.expo.sendPushNotificationsAsync(chunk);
+        for (const ticket of tickets) {
+          if (ticket.status === 'error') {
+            this.logger.warn(
+              `Expo rejected push for customer ${customerId}: ${ticket.message}`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to send push to customer ${customerId}: ${(err as Error).message}`,
+      );
+    }
   }
 
   /** Convenience wrapper for the order-created event. */


### PR DESCRIPTION
Installs expo-server-sdk in server and uncomments the three activation sites in ExpoPushService.ts. Removes the stub log. Push delivery now goes through the real Expo push API rather than logging.
Tested: server typecheck clean, server boots clean with all modules loaded, polling services run, full smoke test on real Android device covering login, account, orders, products, cart. SDK activation introduces no regressions in non-push flows.
Not tested end-to-end: actual notification delivery to device. 