### PR TITLE
Filter out Null Inventory Proudcts

### DIFF
--- a/features/auth/components/RegisterForm.tsx
+++ b/features/auth/components/RegisterForm.tsx
@@ -126,6 +126,7 @@ export default function RegisterForm() {
               returnKeyType='next'
               type='tel'
               name='phone'
+              maxLength={10}
               label='Phone'
               placeholder='123-456-7890'
               required

--- a/features/products/components/ProductsListScreen.tsx
+++ b/features/products/components/ProductsListScreen.tsx
@@ -16,6 +16,7 @@ export default function ProductsListScreen() {
         isLoading={isLoading}
         error={error}
         noDataComponent={<NoProductsAvailable />}
+        refetch={refetch}
       >
         {(products) => (
           <ProductGrid

--- a/features/products/hooks/useProductDetails.tsx
+++ b/features/products/hooks/useProductDetails.tsx
@@ -17,6 +17,8 @@ export const useProductDetails = (productId: number, options?: QueryOptions<Prod
         .GET('/api/products/{productId}', { params: { path: { productId } } })
         .then(unwrapResponse),
     enabled: !!productId,
+    staleTime: 0,
+    refetchOnMount: true,
     ...options,
   });
 };

--- a/server/src/features/products/queries/GetProducts/GetProductsQueryHandler.ts
+++ b/server/src/features/products/queries/GetProducts/GetProductsQueryHandler.ts
@@ -20,6 +20,9 @@ export class GetProductsQueryHandler implements IQueryHandler<GetProductsQuery> 
 
   async execute(): Promise<ProductListItemDto[]> {
     const products = await this.prisma.product.findMany({
+      where: {
+        inventory: { some: {} },
+      },
       include: {
         category: true,
         inventory: true,


### PR DESCRIPTION
- Filter out any product that inventory is null when fetching products.
- Refetch products on the mount so that legacy devices are not cached
- Fix product datawrapper to include refetch
- Fixed phone number on Register page (not related to this issue)