### PR TITLE
Implement suggested products feature in product detail screen

### DIFF
--- a/app/(auth)/products/[id].tsx
+++ b/app/(auth)/products/[id].tsx
@@ -1,24 +1,67 @@
 import { DataWrapper } from '@/components/DataWrapper';
-import { ProductDetails } from '@/features/products/components/ProductDetails';
+import { AddToCartButton, ProductDetails } from '@/features/products/components/ProductDetails';
+import { useGetSuggestedProducts } from '@/features/products/hooks/useGetSuggestedProducts';
 import { useProductDetails } from '@/features/products/hooks/useProductDetails';
 import { useLocalSearchParams } from 'expo-router';
+import { RefreshControl, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function PublicProductDetailScreen() {
   const { id } = useLocalSearchParams() as { id: string };
-  const { data, isLoading, error } = useProductDetails(Number(id));
+  const productId = Number(id);
+  const productQuery = useProductDetails(productId);
+  const suggestedQuery = useGetSuggestedProducts(productId, {
+    enabled: !!productQuery.data,
+  });
+
+  const refreshing =
+    (productQuery.isFetching && !productQuery.isPending) ||
+    (!!productQuery.data && suggestedQuery.isFetching && !suggestedQuery.isPending);
+
+  const handleRefresh = () => {
+    void Promise.all([productQuery.refetch(), suggestedQuery.refetch()]);
+  };
+
   return (
     <SafeAreaView
       className='flex-1 bg-background'
       edges={['bottom']}
     >
-      <DataWrapper
-        data={data}
-        isLoading={isLoading}
-        error={error}
-      >
-        {(product) => <ProductDetails product={product} />}
-      </DataWrapper>
+      <View className='flex-1'>
+        <DataWrapper
+          data={productQuery.data}
+          isLoading={productQuery.isPending}
+          error={productQuery.error}
+          refetch={productQuery.refetch}
+        >
+          {(product) => (
+            <>
+              <ScrollView
+                className='flex-1'
+                contentContainerStyle={{ flexGrow: 1, padding: 16, gap: 16 }}
+                refreshControl={
+                  <RefreshControl
+                    refreshing={refreshing}
+                    onRefresh={handleRefresh}
+                  />
+                }
+                showsVerticalScrollIndicator={false}
+              >
+                <ProductDetails
+                  product={product}
+                  suggested={{
+                    data: suggestedQuery.data,
+                    isLoading: suggestedQuery.isLoading,
+                    error: suggestedQuery.error,
+                    refetch: suggestedQuery.refetch,
+                  }}
+                />
+              </ScrollView>
+              <AddToCartButton product={product} />
+            </>
+          )}
+        </DataWrapper>
+      </View>
     </SafeAreaView>
   );
 }

--- a/features/products/components/ProductDetails.tsx
+++ b/features/products/components/ProductDetails.tsx
@@ -5,105 +5,107 @@ import { Text } from '@/components/ui/text';
 import { useAddToCart } from '@/features/cart/hooks/useAddToCart';
 import { PRODUCT_PLACEHOLDER_IMAGE_URL } from '@/lib/constants';
 import { formatCurrency } from '@/lib/utils';
-import { ActivityIndicator, Image, ScrollView, View } from 'react-native';
-import { useProducts } from '../hooks/useProducts';
-import { ProductDetail, ProductInventory } from '../types';
+import { ActivityIndicator, Image, View } from 'react-native';
+import { ProductDetail, ProductInventory, ProductListItem } from '../types';
 import { ProductHorizontalList } from './ProductHorizontalList';
 
-export function ProductDetails({ product }: { product: ProductDetail }) {
-  const { data, isLoading, error } = useProducts();
+export type ProductDetailsSuggestedProps = {
+  data: ProductListItem[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+};
+
+export function ProductDetails({
+  product,
+  suggested,
+}: {
+  product: ProductDetail;
+  suggested: ProductDetailsSuggestedProps;
+}) {
+  const { data, isLoading, error, refetch } = suggested;
 
   const getTotalQuantity = (inventory: ProductInventory[]) =>
     inventory?.reduce((sum, inv) => sum + inv.quantity, 0) ?? 0;
   const totalQuantity = getTotalQuantity(product.inventory);
   const formattedPrice = formatCurrency(product.lowestPrice);
   return (
-    <View className='flex-1'>
-      <ScrollView
-        contentContainerStyle={{ padding: 16, gap: 16 }}
-        showsVerticalScrollIndicator={false}
-      >
-        {/* Header row: image + info */}
-        <View className='flex-row gap-4'>
-          {product!.imageUrl ? (
-            <Image
-              source={{ uri: product!.imageUrl }}
-              className='w-28 h-28 rounded-xl bg-muted'
-              resizeMode='cover'
-            />
-          ) : (
-            <Image
-              source={{ uri: PRODUCT_PLACEHOLDER_IMAGE_URL }}
-              className='w-28 h-28 rounded-xl bg-muted'
-              resizeMode='cover'
-            />
-          )}
+    <View className='gap-4'>
+      {/* Header row: image + info */}
+      <View className='flex-row gap-4'>
+        {product!.imageUrl ? (
+          <Image
+            source={{ uri: product!.imageUrl }}
+            className='w-28 h-28 rounded-xl bg-muted'
+            resizeMode='cover'
+          />
+        ) : (
+          <Image
+            source={{ uri: PRODUCT_PLACEHOLDER_IMAGE_URL }}
+            className='w-28 h-28 rounded-xl bg-muted'
+            resizeMode='cover'
+          />
+        )}
 
-          <View className='flex-1 justify-center gap-1'>
-            <Text className='text-muted-foreground text-xs'>
-              {product.category?.categoryName ?? '-'}
-            </Text>
-            <Text className='font-bold text-base leading-snug'>{product.productName ?? '-'}</Text>
-            <Text className='text-muted-foreground text-sm'>Qty: {totalQuantity ?? 0}</Text>
-            <Text className='font-semibold text-foreground text-base'>{formattedPrice ?? 0}</Text>
-          </View>
-        </View>
-
-        {/* Stock status badge */}
-        <View className='flex-row'>
-          {product!.inStock ? (
-            <Badge variant={'success'}>
-              <Text>In Stock</Text>
-            </Badge>
-          ) : (
-            <Badge variant={'destructive'}>
-              <Text>Out of Stock</Text>
-            </Badge>
-          )}
-        </View>
-
-        {/* Description */}
-        <View className='gap-1'>
-          <Text className='text-foreground leading-relaxed'>
-            {product.productDescription ?? 'No description available.'}
+        <View className='flex-1 justify-center gap-1'>
+          <Text className='text-muted-foreground text-xs'>
+            {product.category?.categoryName ?? '-'}
           </Text>
+          <Text className='font-bold text-base leading-snug'>{product.productName ?? '-'}</Text>
+          <Text className='text-muted-foreground text-sm'>Qty: {totalQuantity ?? 0}</Text>
+          <Text className='font-semibold text-foreground text-base'>{formattedPrice ?? 0}</Text>
         </View>
+      </View>
 
-        {/* Supplier */}
-        <Text className='text-muted-foreground text-xs'>
-          Supplied by {product.supplier?.supplierName ?? '-'}
+      {/* Stock status badge */}
+      <View className='flex-row'>
+        {product!.inStock ? (
+          <Badge variant={'success'}>
+            <Text>In Stock</Text>
+          </Badge>
+        ) : (
+          <Badge variant={'destructive'}>
+            <Text>Out of Stock</Text>
+          </Badge>
+        )}
+      </View>
+
+      {/* Description */}
+      <View className='gap-1'>
+        <Text className='text-foreground leading-relaxed'>
+          {product.productDescription ?? 'No description available.'}
         </Text>
+      </View>
 
-        {/* Suggested products */}
-        <DataWrapper
-          data={data}
-          isLoading={isLoading}
-          error={error}
-        >
-          {(products) => {
-            const suggestions = products
-              .filter((p) => p.productId !== product.productId)
-              .slice(0, 8);
-            return (
-              <View className='gap-3'>
-                <Text className='font-semibold text-base'>Suggested</Text>
-                <ProductHorizontalList
-                  products={suggestions}
-                  navigateFromProductDetail
-                />
-              </View>
-            );
-          }}
-        </DataWrapper>
-      </ScrollView>
+      {/* Supplier */}
+      <Text className='text-muted-foreground text-xs'>
+        Supplied by {product.supplier?.supplierName ?? '-'}
+      </Text>
 
-      {/* Add to Cart footer */}
-      <AddToCartButton product={product} />
+      {/* Suggested products */}
+      <DataWrapper
+        data={data}
+        isLoading={isLoading}
+        error={error}
+        refetch={refetch}
+      >
+        {(products) => {
+          return (
+            <View className='gap-3'>
+              <Text className='font-semibold text-base'>Suggested</Text>
+              <ProductHorizontalList
+                products={products}
+                navigateFromProductDetail
+              />
+            </View>
+          );
+        }}
+      </DataWrapper>
     </View>
   );
 }
 
-function AddToCartButton({
+export function AddToCartButton({
   product,
   button,
 }: {

--- a/features/products/hooks/shared.ts
+++ b/features/products/hooks/shared.ts
@@ -18,5 +18,6 @@ export const productQueryKeys = {
   /** Base key for all product list queries. */
   products: ['products'],
   list: () => [...productQueryKeys.products, 'list'] as const,
+  suggested: (productId: number) => [...productQueryKeys.list(), 'suggested', productId] as const,
   details: (productId: number) => [...productQueryKeys.products, 'details', productId] as const,
 };

--- a/features/products/hooks/useGetSuggestedProducts.tsx
+++ b/features/products/hooks/useGetSuggestedProducts.tsx
@@ -1,0 +1,19 @@
+import { apiClient } from '@/lib/apiClient';
+import { unwrapResponse } from '@/lib/unwrapResponse';
+import { QueryOptions } from '@/types/QueryOptions';
+import { useQuery } from '@tanstack/react-query';
+import { ProductListItem } from '../types';
+import { productQueryKeys } from './shared';
+
+export const useGetSuggestedProducts = (
+  productId: number,
+  options?: QueryOptions<ProductListItem[]>,
+) =>
+  useQuery({
+    queryKey: productQueryKeys.suggested(productId),
+    queryFn: async () =>
+      apiClient
+        .GET(`/api/products/{productId}/suggested`, { params: { path: { productId } } })
+        .then(unwrapResponse),
+    ...options,
+  });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -49,7 +49,12 @@ export function getRandomShippingCost() {
   return Math.floor(Math.random() * (hi - lo + 1)) + lo;
 }
 
-export function formatCurrency(amount: number) {
-  if (!Number.isFinite(amount)) return 'N/A';
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+/**
+ * API / raw SQL DECIMAL values are often serialized as strings; coerce before formatting.
+ */
+export function formatCurrency(amount: number | string | null | undefined) {
+  if (amount == null || amount === '') return 'N/A';
+  const n = typeof amount === 'number' ? amount : Number(String(amount).trim());
+  if (!Number.isFinite(n)) return 'N/A';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
 }

--- a/server/src/features/products/Products.controller.ts
+++ b/server/src/features/products/Products.controller.ts
@@ -11,6 +11,7 @@ import { ProductDetailDto } from './dtos/ProductDetail.dto';
 import { ProductListItemDto } from './dtos/ProductListItem.dto';
 import { GetProductDetailsQuery } from './queries/GetProductDetails/GetProductDetailsQuery';
 import { GetProductsQuery } from './queries/GetProducts/GetProductsQuery';
+import { GetSuggestedProductsQuery } from './queries/GetSuggestedProducts/GetSuggestedProductsQuery';
 
 @Controller('products')
 @ApiTags('Products')
@@ -34,5 +35,17 @@ export class ProductsController {
   @ApiOkResponse({ type: ProductDetailDto })
   async getProductById(@Param('productId', ParseIntPipe) productId: number) {
     return this.queryBus.execute(new GetProductDetailsQuery(productId));
+  }
+
+  // get prod by id
+  @Get(':productId/suggested')
+  @Public()
+  @ApiOperation({ summary: 'Get product by productId' })
+  @ApiParam({ type: Number, required: true, name: 'productId' })
+  @ApiOkResponse({ type: [ProductListItemDto] })
+  async getSuggestedProducts(
+    @Param('productId', ParseIntPipe) productId: number,
+  ) {
+    return this.queryBus.execute(new GetSuggestedProductsQuery(productId));
   }
 }

--- a/server/src/features/products/Products.module.ts
+++ b/server/src/features/products/Products.module.ts
@@ -2,9 +2,14 @@ import { Module } from '@nestjs/common';
 import { ProductsController } from './Products.controller';
 import { GetProductDetailsQueryHandler } from './queries/GetProductDetails/GetProductDetailsQueryHandler';
 import { GetProductsQueryHandler } from './queries/GetProducts/GetProductsQueryHandler';
+import { GetSuggestedProductsQueryHandler } from './queries/GetSuggestedProducts/GetSuggestedProductsQueryHandler';
 
 @Module({
-  providers: [GetProductsQueryHandler, GetProductDetailsQueryHandler],
+  providers: [
+    GetProductsQueryHandler,
+    GetProductDetailsQueryHandler,
+    GetSuggestedProductsQueryHandler,
+  ],
   controllers: [ProductsController],
 })
 export class ProductsModule {}

--- a/server/src/features/products/queries/GetSuggestedProducts/GetSuggestedProductsQuery.ts
+++ b/server/src/features/products/queries/GetSuggestedProducts/GetSuggestedProductsQuery.ts
@@ -1,0 +1,8 @@
+import { Query } from '@nestjs/cqrs';
+import { ProductListItemDto } from '../../dtos/ProductListItem.dto';
+
+export class GetSuggestedProductsQuery extends Query<ProductListItemDto[]> {
+  constructor(public readonly productId: number) {
+    super();
+  }
+}

--- a/server/src/features/products/queries/GetSuggestedProducts/GetSuggestedProductsQueryHandler.ts
+++ b/server/src/features/products/queries/GetSuggestedProducts/GetSuggestedProductsQueryHandler.ts
@@ -1,0 +1,94 @@
+import { PrismaService } from '@/services/Prisma.service';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { ProductListItemDto } from '../../dtos/ProductListItem.dto';
+import { GetSuggestedProductsQuery } from './GetSuggestedProductsQuery';
+
+interface RawSuggestedProduct {
+  Product_ID: number;
+  Product_Name: string;
+  Product_Description: string | null;
+  Category_ID: number;
+  Category_Name: string;
+  Supplier_ID: number;
+  Image_URL: string | null;
+  Deleted_At: Date | null;
+  Purchase_Count: number;
+  Sort_Priority: number;
+  Quantity: number;
+  Unit_Price: number | string;
+}
+
+@QueryHandler(GetSuggestedProductsQuery)
+export class GetSuggestedProductsQueryHandler implements IQueryHandler<GetSuggestedProductsQuery> {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async execute(
+    query: GetSuggestedProductsQuery,
+  ): Promise<ProductListItemDto[]> {
+    const { productId } = query;
+
+    const currentProduct = await this.prisma.product.findUnique({
+      where: { Product_ID: productId },
+      select: { Category_ID: true },
+    });
+
+    const suggestedProducts = await this.prisma.$queryRaw<
+      RawSuggestedProduct[]
+    >`
+      SELECT * FROM (
+        -- First: same category products ranked by purchase count
+        SELECT 
+          p.*,
+          i.Quantity,
+          i.Unit_Price,
+          c.Category_Name,
+          COUNT(oi.Order_ID) as Purchase_Count,
+          0 as Sort_Priority  -- lower = shown first
+        FROM Order_Item oi
+        JOIN Inventory i ON oi.Inventory_ID = i.Inventory_ID
+        JOIN Product p ON i.Product_ID = p.Product_ID
+        JOIN Product_Category c on c.Category_ID = p.Category_ID
+        WHERE 
+          p.Category_ID = ${currentProduct?.Category_ID}
+          AND p.Product_ID != ${productId}
+        GROUP BY p.Product_ID, i.Quantity, i.Unit_Price, c.Category_Name
+
+        UNION ALL
+
+        -- Fallback: top products from any other category
+        SELECT 
+          p.*,
+          i.Quantity,
+          i.Unit_Price,
+          c.Category_Name,
+          COUNT(oi.Order_ID) as Purchase_Count,
+          1 as Sort_Priority
+        FROM Order_Item oi
+        JOIN Inventory i ON oi.Inventory_ID = i.Inventory_ID
+        JOIN Product p ON i.Product_ID = p.Product_ID
+        JOIN Product_Category c on c.Category_ID = p.Category_ID
+        WHERE 
+          p.Category_ID != ${currentProduct?.Category_ID}
+          AND p.Product_ID != ${productId}
+        GROUP BY p.Product_ID, i.Quantity, i.Unit_Price, c.Category_Name
+      ) as Combined
+      ORDER BY Sort_Priority ASC, Purchase_Count DESC
+      LIMIT 5
+   `;
+
+    return suggestedProducts.map((product) => ({
+      productId: product.Product_ID,
+      productName: product.Product_Name,
+      productDescription: product.Product_Description,
+      category: {
+        categoryId: product.Category_ID,
+        categoryName: product.Category_Name,
+      },
+      supplier: product.Supplier_ID,
+      imageUrl: product.Image_URL,
+      deletedAt: product.Deleted_At,
+      inStock: product.Quantity > 0,
+      unitPrice: Number(product.Unit_Price),
+    }));
+  }
+}

--- a/types/QueryOptions.ts
+++ b/types/QueryOptions.ts
@@ -1,2 +1,8 @@
-import { type QueryOptions as TanstackQueryOptions } from '@tanstack/react-query';
-export type QueryOptions<T> = Omit<TanstackQueryOptions<T>, 'queryKey' | 'queryFn'>;
+import type { DefaultError, QueryKey, UseQueryOptions } from '@tanstack/react-query';
+
+export type QueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'>;

--- a/types/types.generated.ts
+++ b/types/types.generated.ts
@@ -261,6 +261,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/products/{productId}/suggested": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get product by productId */
+        get: operations["ProductsController_getSuggestedProducts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/addresses": {
         parameters: {
             query?: never;
@@ -1812,6 +1829,75 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProductDetailDto"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestException"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthorizedException"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenException"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundException"];
+                };
+            };
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConflictException"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorException"];
+                };
+            };
+        };
+    };
+    ProductsController_getSuggestedProducts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                productId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductListItemDto"][];
                 };
             };
             400: {


### PR DESCRIPTION
- Added `useGetSuggestedProducts` hook to fetch suggested products based on the current product's category.
- Updated `ProductDetails` component to display suggested products alongside product details.
- Enhanced `PublicProductDetailScreen` to include a pull-to-refresh functionality for both product details and suggested products.
- Introduced new API endpoint for fetching suggested products in the backend.
- Refactored currency formatting to handle various input types more robustly.