### PR TITLE
Fix Payment Method Selector Spacing

### DIFF
--- a/features/account/components/AccountCard.tsx
+++ b/features/account/components/AccountCard.tsx
@@ -16,12 +16,12 @@ export function AccountCard({ customer }: AccountCardProps) {
   const { firstName, lastName, email, phone } = customer;
   const router = useRouter();
 
-   const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+  const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
 
   return (
     <Pressable onPress={() => router.push(`/account/${customer.id}`)}>
-    <Card className="w-full">
+      <Card className="w-full">
         <CardContent className="flex-row items-center gap-4">
           <Avatar alt={''} className="size-16">
             <AvatarFallback>
@@ -32,7 +32,7 @@ export function AccountCard({ customer }: AccountCardProps) {
           <View className="flex-1 gap-1">
             <Text className="font-semibold text-base">{firstName} {lastName}</Text>
             <Text className="text-muted-foreground text-sm">{email}</Text>
-            <Text className="text-muted-foreground text-sm">{formatPhoneNumber(phone?? undefined)}</Text>
+            <Text className="text-muted-foreground text-sm">{formatPhoneNumber(phone ?? undefined)}</Text>
           </View>
           <View className="flex-row items-center">
             <ChevronRight size={18} className="text-muted-foreground" />

--- a/features/checkout/components/CheckoutDetailsScreen.tsx
+++ b/features/checkout/components/CheckoutDetailsScreen.tsx
@@ -15,7 +15,7 @@ import { ShoppingCart } from '../../cart/types';
 import { CheckoutFormValues, checkoutSchema } from '../checkout.schema';
 import { AddressSelector } from './AddressSelector';
 import { CheckoutHorizontalList } from './CheckoutHorizontalList';
-import { SelectPaymentCard } from './PaymentMethodSelector';
+import { PaymentMethodSelector } from './PaymentMethodSelector';
 import { PurchaseButton } from './PurchaseButton';
 import { SummaryCardRow } from './SummaryCardRow';
 
@@ -49,11 +49,7 @@ export function CheckoutDetails({ cart }: { cart: ShoppingCart }) {
   // Discounted subtotal mirrors what the server will store on Order_Item.Amount.
   // Tax is then computed on the discounted amount to match the server.
   const totalPrice = useMemo(
-    () =>
-      items.reduce(
-        (total, item) => total + applyDiscount(item.unitPrice) * item.quantity,
-        0,
-      ),
+    () => items.reduce((total, item) => total + applyDiscount(item.unitPrice) * item.quantity, 0),
     [items, applyDiscount],
   );
   const discountAmount = originalSubtotal - totalPrice;
@@ -143,7 +139,7 @@ export function CheckoutDetails({ cart }: { cart: ShoppingCart }) {
           {!isBillingAddressSameAsShippingAddress && <AddressSelector type='billing' />}
 
           {/* Payment methods */}
-          <SelectPaymentCard />
+          <PaymentMethodSelector />
 
           <PurchaseButton />
         </ScrollView>

--- a/features/checkout/components/PaymentMethodSelector.tsx
+++ b/features/checkout/components/PaymentMethodSelector.tsx
@@ -1,11 +1,5 @@
 import { Card } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Text } from '@/components/ui/text';
 import { PaymentMethod, getPaymentLabel } from '@/types/PaymentMethod.enum';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -13,7 +7,7 @@ import { Platform, View } from 'react-native';
 import { CheckoutFormValues } from '../checkout.schema';
 import { CreditCardForm } from './CreditCardForm';
 
-export function SelectPaymentCard() {
+export function PaymentMethodSelector() {
   const form = useFormContext<CheckoutFormValues>();
 
   const filteredPaymentMethods = Object.values(PaymentMethod).filter((method) => {
@@ -21,6 +15,11 @@ export function SelectPaymentCard() {
     if (Platform.OS === 'android' && method === PaymentMethod.APPLE_PAY) return false;
     return true;
   });
+
+  const items = filteredPaymentMethods.map((method) => ({
+    label: getPaymentLabel(method),
+    value: method,
+  }));
 
   return (
     <Card className='gap-0 px-4 py-3'>
@@ -31,31 +30,19 @@ export function SelectPaymentCard() {
           name='paymentMethod'
           render={({ field }) => (
             <View>
-              <Select
-                value={{ label: getPaymentLabel(field.value), value: field.value }}
-                onValueChange={(option) => {
-                  if (option?.value) {
-                    field.onChange(option.value as PaymentMethod);
-                    if (option.value !== PaymentMethod.CREDIT_CARD) {
-                      form.setValue('creditCard', undefined);
-                    }
+              <Combobox<PaymentMethod>
+                items={items}
+                placeholder='Select a payment method'
+                searchPlaceholder='Search payment methods'
+                value={field.value}
+                onChange={(value) => {
+                  field.onChange(value);
+                  if (value !== PaymentMethod.CREDIT_CARD) {
+                    form.setValue('creditCard', undefined);
                   }
                 }}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder='Select a payment method' />
-                </SelectTrigger>
-                <SelectContent>
-                  {filteredPaymentMethods.map((method) => (
-                    <SelectItem
-                      key={method}
-                      value={method}
-                      label={getPaymentLabel(method)}
-                      className='text-foreground'
-                    />
-                  ))}
-                </SelectContent>
-              </Select>
+                multiple={false}
+              />
               {field.value === 'CREDIT_CARD' && <CreditCardForm />}
             </View>
           )}


### PR DESCRIPTION
The payment method selector would extend past the end of the screen on smaller screen sizes. 
- Updated component to use the `Combobox` component that the ' AddressForm ' uses, which allows a modal to be present for easy selection. 
- Fixed naming convention on `PaymentMethodSelector` to match the file name. 
- 